### PR TITLE
docs: capture ISSUE-030 for resolved CI false negative

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -64,7 +64,7 @@ Tasks, docs de arquitectura, o commits relacionados.
 
 ## Siguiente ID disponible
 
-`ISSUE-030`
+`ISSUE-031`
 
 ## Open
 
@@ -101,6 +101,7 @@ Tasks, docs de arquitectura, o commits relacionados.
 | `ISSUE-007` | [Finance fallback writes can duplicate income and expenses](resolved/ISSUE-007-finance-fallback-writes-can-duplicate-income-and-expenses.md)                      | preview + production           | 2026-04-05 | 2026-04-05 | Fallback recalculaba un segundo ID en `income` y `expenses`                                                              |
 | `ISSUE-008` | [Finance routes mask schema drift as empty success](resolved/ISSUE-008-finance-routes-mask-schema-drift-as-empty-success.md)                                      | preview + production           | 2026-04-05 | 2026-04-05 | Routes devolvían vacío ambiguo ante drift de schema                                                                      |
 | `ISSUE-026` | [Mi Perfil crash: leave.requests nested object + auth redirect](resolved/ISSUE-026-my-profile-crash-leave-requests-nested-object.md)                              | production + staging           | 2026-04-07 | 2026-04-07 | `leave?.requests` es objeto anidado no array; fallback auth a `/dashboard` en vez de `/home`                             |
-| `ISSUE-029` | [HubSpot sync falla por columnas incorrectas en identity_profiles](resolved/ISSUE-029-hubspot-sync-identity-profiles-column-mismatch.md)                              | staging + production           | 2026-04-07 | 2026-04-07 | `source_system` → `primary_source_system` + `profile_type` NOT NULL faltante en INSERT                                   |
+| `ISSUE-029` | [HubSpot sync falla por columnas incorrectas en identity_profiles](resolved/ISSUE-029-hubspot-sync-identity-profiles-column-mismatch.md)                          | staging + production           | 2026-04-07 | 2026-04-07 | `source_system` → `primary_source_system` + `profile_type` NOT NULL faltante en INSERT                                   |
 | `ISSUE-028` | [HubSpot Cloud Run service 401: Private App Token expirado](resolved/ISSUE-028-hubspot-cloud-run-token-expired.md)                                                | staging + production           | 2026-04-07 | 2026-04-07 | Private App Token en Secret Manager revocado; rotado a version 2 + Cloud Run service update                              |
 | `ISSUE-001` | [SSL bad certificate en webhook-dispatch](resolved/ISSUE-001-ssl-bad-certificate-production.md)                                                                   | production                     | 2026-03-30 | 2026-03-30 | `GREENHOUSE_POSTGRES_IP_TYPE` faltante en production                                                                     |
+| `ISSUE-030` | [CI: test stale de OrganizationPeopleTab bloquea PRs no relacionados](resolved/ISSUE-030-ci-stale-organization-people-tab-test-blocks-unrelated-prs.md)           | preview + GitHub Actions CI    | 2026-04-08 | 2026-04-08 | El test asumía 1 `fetch()` y un solo `1.0`, pero el componente ya cargaba memberships + faceta `team` y renderizaba KPI  |

--- a/docs/issues/resolved/ISSUE-030-ci-stale-organization-people-tab-test-blocks-unrelated-prs.md
+++ b/docs/issues/resolved/ISSUE-030-ci-stale-organization-people-tab-test-blocks-unrelated-prs.md
@@ -1,0 +1,96 @@
+# ISSUE-030 — CI: test stale de OrganizationPeopleTab bloquea PRs no relacionados
+
+## Ambiente
+
+GitHub Actions CI (`Lint, test and build`) sobre `preview + main`
+
+## Detectado
+
+2026-04-08, durante revisión de PRs abiertos `#41` y `#42` en GitHub.
+
+## Síntoma
+
+PRs funcionalmente no relacionados quedaban bloqueados por el mismo check rojo en GitHub Actions.
+
+- `#41` (`fix: route PDF/XML downloads through server proxy to avoid Nubox 401`)
+- `#42` (`docs: create TASK-284 shareholder current account (CCA)`)
+
+Ambos fallaban en el mismo test:
+
+- `src/views/greenhouse/organizations/tabs/OrganizationPeopleTab.test.tsx`
+
+El error observable en CI era:
+
+```text
+AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
+```
+
+Luego, al alinear la expectativa de requests, apareció un segundo falso negativo:
+
+```text
+Found multiple elements with the text: 1.0
+```
+
+## Causa raíz
+
+`OrganizationPeopleTab` evolucionó para cargar dos fuentes al montar:
+
+- `/api/organizations/[id]/memberships`
+- `/api/organization/[id]/360?facets=team`
+
+El test seguía modelando una versión anterior del componente:
+
+- esperaba un solo `fetch()`
+- asumía que `1.0` sólo se renderizaba una vez
+
+Con la incorporación de KPIs de la faceta `team`, `1.0` pasó a aparecer tanto en el KPI `FTE total` como en la fila de la tabla.
+
+## Impacto
+
+- **Proceso**: PRs ajenos al tab de organizaciones quedaban bloqueados por un falso negativo de baseline.
+- **Señal de CI degradada**: un PR de solo documentación (`#42`) aparecía roto aunque no tocara runtime.
+- **Costo operativo**: se perdía tiempo investigando cambios equivocados cuando la rotura real estaba en la suite compartida.
+
+## Solución
+
+Se actualizó `src/views/greenhouse/organizations/tabs/OrganizationPeopleTab.test.tsx` para reflejar el comportamiento vigente del componente:
+
+- mockear dos respuestas (`memberships` + `360?facets=team`)
+- validar ambos endpoints esperados
+- validar la presencia del KPI `FTE total`
+- aceptar que `1.0` aparece dos veces (`KPI + tabla`)
+
+El fix se publicó como:
+
+- PR `#43` — `fix: align organization people tab test with 360 fetches`
+
+## Verificación
+
+Validación local ejecutada sobre el fix:
+
+- `pnpm exec vitest run src/views/greenhouse/organizations/tabs/OrganizationPeopleTab.test.tsx` — OK
+- `pnpm test` — OK
+- `pnpm lint` — OK
+- `pnpm build` — OK
+
+Verificación operativa adicional:
+
+- PR `#43` cerró la rotura de baseline de CI
+- después de actualizar ramas, `#41` y `#42` pudieron cerrarse sin quedar bloqueados por ese test stale
+
+Nota:
+
+- El failure de `Vercel` preview observado en `#41`, `#42` y `#43` quedó fuera del alcance de este issue porque no estaba resuelto al cierre y no provenía del diff de esos PRs.
+
+## Estado
+
+resolved
+
+## Relacionado
+
+- `src/views/greenhouse/organizations/tabs/OrganizationPeopleTab.tsx`
+- `src/views/greenhouse/organizations/tabs/OrganizationPeopleTab.test.tsx`
+- PR `#41`
+- PR `#42`
+- PR `#43`
+- `Handoff.md`


### PR DESCRIPTION
## Summary
- add `ISSUE-030` to document the resolved CI false negative around `OrganizationPeopleTab`
- update `docs/issues/README.md` with the new resolved issue and advance the next available ID to `ISSUE-031`
- preserve the operational learning that the CI failure was resolved, while keeping the unresolved Vercel preview incident out of the resolved issue

## Why
PRs `#41` and `#42` were being blocked by a stale shared test even though the underlying changes were unrelated. This turned a local test drift into repo-wide CI noise. Capturing that as a resolved issue keeps the learning searchable for future agents and operators.

## Validation
- reviewed `docs/issues/resolved/ISSUE-030-ci-stale-organization-people-tab-test-blocks-unrelated-prs.md`
- reviewed `docs/issues/README.md`
- `pnpm exec prettier --write docs/issues/README.md docs/issues/resolved/ISSUE-030-ci-stale-organization-people-tab-test-blocks-unrelated-prs.md`
