### PR TITLE
fix: harden preview auth builds against missing nextauth secret

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,33 @@
 # Handoff.md
 
+## Sesion 2026-04-08 — ISSUE-031 resolved: Vercel Preview build no longer dies on missing NEXTAUTH_SECRET
+
+- contexto:
+  - los PR `#41`, `#42` y `#43` seguian mostrando `Vercel: Error` aun despues de limpiar la baseline de CI
+  - la reproduccion inicial local daba falso verde porque Next estaba leyendo `.env.production.local`
+- causa raiz confirmada:
+  - al aislar el entorno real de `Preview` (solo `.vercel/.env.preview.local`, sin `.env.local` ni `.env.production.local`), `pnpm build` fallo con:
+    - `NEXTAUTH_SECRET is not set`
+    - `Failed to collect page data for /api/admin/invite`
+  - `Preview` tambien venia sin `NEXTAUTH_URL`, `GCP_PROJECT` y `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+  - el trigger tecnico del build rojo era que `src/lib/auth.ts` resolvia `authOptions` en import-time
+- fix aplicado:
+  - `src/lib/auth.ts` ahora resuelve auth lazy via `getAuthOptions()` y `getServerAuthSession()`
+  - los consumers server-side dejaron de importar `authOptions` eager
+  - `src/app/api/auth/[...nextauth]/route.ts` ahora devuelve `503` controlado si falta configuracion de auth
+- validacion ejecutada:
+  - `pnpm build` — OK
+  - `pnpm lint` — OK
+  - `pnpm build` con solo `.vercel/.env.preview.local` — OK
+- documentacion actualizada:
+  - `project_context.md`
+  - `changelog.md`
+  - `docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md`
+  - `docs/issues/README.md`
+- nota operativa:
+  - el hardening evita que `Preview` quede rojo por drift de env
+  - si una branch preview necesita login real, Vercel igual debe tener `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GCP_PROJECT` y credenciales Google validas
+
 ## Sesion 2026-04-08 — CI root cause for open PRs 41/42
 
 - contexto:

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026-04-08
 
+### 2026-04-08 — Vercel Preview auth drift hardening
+
+- Se resolvió el incidente donde los Preview Deployments de Vercel quedaban en `Error` por `NEXTAUTH_SECRET` faltante durante `page-data collection`.
+- `src/lib/auth.ts` pasó a resolver `NextAuthOptions` de forma lazy y los consumers server-side ahora usan `getServerAuthSession()`.
+- Si un runtime carece de `NEXTAUTH_SECRET`, el build ya no se cae: el portal degrada a sesión `null` y `/api/auth/[...nextauth]` responde `503` controlado.
+- El incidente quedó documentado como `ISSUE-031`.
+
 ### 2026-04-08 — Hotfix productivo Banco: materializacion de balances corregida
 
 - Fix post-merge de `Finance > Banco`: `GET /api/finance/bank` en produccion estaba devolviendo `500` por un descalce entre placeholders SQL y parametros enviados durante la materializacion de `account_balances`.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -64,7 +64,7 @@ Tasks, docs de arquitectura, o commits relacionados.
 
 ## Siguiente ID disponible
 
-`ISSUE-031`
+`ISSUE-032`
 
 ## Open
 
@@ -83,6 +83,7 @@ Tasks, docs de arquitectura, o commits relacionados.
 
 | ID          | Título                                                                                                                                                            | Ambiente                       | Detectado  | Resuelto   | Causa                                                                                                                    |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `ISSUE-031` | [Vercel Preview falla en build por drift de `NEXTAUTH_SECRET`](resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md)                        | preview                        | 2026-04-08 | 2026-04-08 | `authOptions` se resolvía en import-time y Preview no tenía `NEXTAUTH_SECRET`, por lo que el build caía en page-data collection |
 | `ISSUE-027` | [My Profile vacío tras migración a Person 360: resolución "me" retorna 404](resolved/ISSUE-027-my-profile-360-me-resolution-404.md)                               | staging                        | 2026-04-07 | 2026-04-07 | `resolvePersonIdentifier` no buscaba por `identity_profile_id` — WHERE clause solo tenía `member_id OR user_id`          |
 | `ISSUE-025` | [sendEmail() reporta 'sent' cuando todos los recipients fueron skipped](resolved/ISSUE-025-sendmail-status-aggregation-skipped-as-sent.md)                        | production + staging + preview | 2026-04-06 | 2026-04-07 | `sendEmail()` no trackeaba `sawSkipped`; 18 registros históricos corregidos via backfill                                 |
 | `ISSUE-024` | [Admin Notifications: errores silenciosos ocultan estado real](resolved/ISSUE-024-admin-notifications-silent-failures-zero-kpis.md)                               | staging + preview              | 2026-04-06 | 2026-04-07 | Catch blocks silenciosos + logDispatch vacío + schema validation faltante + diagnostics UI ausente                       |

--- a/docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md
+++ b/docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md
@@ -1,0 +1,79 @@
+# ISSUE-031 — Vercel Preview falla en build por drift de `NEXTAUTH_SECRET`
+
+## Ambiente
+
+preview
+
+## Detectado
+
+2026-04-08, durante la revisión de los PR `#41`, `#42` y `#43`.
+
+## Síntoma
+
+Los Preview Deployments de Vercel quedaban en `Error` aunque:
+
+- `pnpm build` pasaba localmente con `.env.local`
+- el diff de los PR no tocaba autenticación
+- incluso un PR solo de docs (`#42`) fallaba igual
+
+La reproducción aislada contra el snapshot real de `Preview` (`.vercel/.env.preview.local`), removiendo `.env.local` y `.env.production.local`, falló con:
+
+```text
+Error: NEXTAUTH_SECRET is not set
+Error: Failed to collect page data for /api/admin/invite
+```
+
+## Causa raíz
+
+El ambiente `Preview` de Vercel tenía drift respecto del baseline local y compartido:
+
+- faltaba `NEXTAUTH_SECRET`
+- faltaba `NEXTAUTH_URL`
+- también faltaban `GCP_PROJECT` y `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+
+El fallo que rompía el deployment aparecía primero en `NEXTAUTH_SECRET` porque `src/lib/auth.ts` resolvía `authOptions` en import-time. Durante `page-data collection`, Next importaba routes y páginas que llamaban `getServerSession(authOptions)`, por lo que el build abortaba antes de terminar.
+
+## Impacto
+
+- PR previews quedaban rojos por un problema de entorno, no por el diff real.
+- GitHub mostraba `Vercel: Error` sin preview URL utilizable.
+- El diagnóstico era engañoso porque el build local normal seguía pasando con `.env.local`.
+
+## Solución
+
+Se endureció el carril de auth para que el drift de Preview no vuelva a bloquear el build:
+
+- `src/lib/auth.ts` ahora construye `NextAuthOptions` de forma lazy (`getAuthOptions()`) en vez de hacerlo al importar el módulo.
+- Los consumers server-side migraron de `getServerSession(authOptions)` a `getServerAuthSession()`.
+- Si falta `NEXTAUTH_SECRET`, `getServerAuthSession()` degrada a sesión `null` en vez de romper el build.
+- `src/app/api/auth/[...nextauth]/route.ts` ahora responde `503` controlado cuando la autenticación no está configurada en ese runtime, en vez de explotar durante import-time.
+
+Esto no reemplaza la política operativa de Vercel: un Preview que necesite login real sigue debiendo tener `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GCP_PROJECT` y credenciales Google válidas. Pero el deployment deja de caer silenciosamente por ese drift.
+
+## Verificación
+
+Validación local ejecutada sobre la rama del fix:
+
+- `pnpm build` — OK
+- `pnpm lint` — OK
+- reproducción aislada de `Preview`:
+  - mover temporalmente `.env.local` y `.env.production.local`
+  - cargar solo `.vercel/.env.preview.local`
+  - `pnpm build` — OK
+
+La reproducción aislada confirmó el before/after:
+
+- antes del fix: `NEXTAUTH_SECRET is not set` durante `page-data collection`
+- después del fix: el build de `Preview` completa
+
+## Estado
+
+resolved
+
+## Relacionado
+
+- `src/lib/auth.ts`
+- `src/app/api/auth/[...nextauth]/route.ts`
+- `project_context.md`
+- `Handoff.md`
+- `ISSUE-030`

--- a/project_context.md
+++ b/project_context.md
@@ -1,5 +1,17 @@
 # project_context.md
 
+## Delta 2026-04-08 Vercel Preview auth hardening
+
+- Se confirmó que `Preview` puede quedar con drift de env respecto de local/shared y faltar al menos `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GCP_PROJECT` o `GOOGLE_APPLICATION_CREDENTIALS_JSON`.
+- `src/lib/auth.ts` ya no debe resolver `NextAuthOptions` en import-time. La resolución canónica ahora es lazy via `getAuthOptions()` y `getServerAuthSession()`.
+- Si `NEXTAUTH_SECRET` falta en `Preview`, el portal ya no debe romper el build:
+  - server components y route handlers degradan a sesión `null`
+  - `src/app/api/auth/[...nextauth]/route.ts` responde `503` controlado en vez de abortar `page-data collection`
+- Regla operativa vigente:
+  - el hardening evita que el deployment quede rojo por drift
+  - pero un Preview que necesite login funcional sigue debiendo tener `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GCP_PROJECT` y credenciales Google válidas
+- Issue resuelto de referencia: `docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md`
+
 ## Delta 2026-04-07 Account Complete 360 — serving federado por facetas (TASK-274)
 
 ### Account Complete 360 (TASK-274)

--- a/src/app/(blank-layout-pages)/login/page.tsx
+++ b/src/app/(blank-layout-pages)/login/page.tsx
@@ -3,9 +3,6 @@ import { redirect } from 'next/navigation'
 
 import type { Metadata } from 'next'
 
-// Third-party Imports
-import { getServerSession } from 'next-auth'
-
 // Component Imports
 import Login from '@views/Login'
 
@@ -14,7 +11,7 @@ import { getServerMode } from '@core/utils/serverHelpers'
 
 // Lib Imports
 import { hasGoogleAuthProvider, hasMicrosoftAuthProvider } from '@/lib/auth-secrets'
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 
 export const metadata: Metadata = {
   title: 'Login',
@@ -22,7 +19,7 @@ export const metadata: Metadata = {
 }
 
 const LoginPage = async () => {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
   const hasMicrosoftAuth = hasMicrosoftAuthProvider()
   const hasGoogleAuth = hasGoogleAuthProvider()
 

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -4,9 +4,6 @@ import { redirect } from 'next/navigation'
 // MUI Imports
 import Button from '@mui/material/Button'
 
-// Third-party Imports
-import { getServerSession } from 'next-auth'
-
 // Type Imports
 import type { ChildrenType } from '@core/types'
 
@@ -30,12 +27,12 @@ import ChunkRecoveryClear from '@/components/ChunkRecoveryClear'
 import { getMode, getSystemMode } from '@core/utils/serverHelpers'
 
 // Lib Imports
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 
 const Layout = async (props: ChildrenType) => {
   const { children } = props
 
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session) {
     redirect('/login')

--- a/src/app/api/admin/identity/reconciliation/[proposalId]/resolve/route.ts
+++ b/src/app/api/admin/identity/reconciliation/[proposalId]/resolve/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { requireAdminTenantContext } from '@/lib/tenant/authorization'
 import { runGreenhousePostgresQuery } from '@/lib/postgres/client'
 import { applyIdentityLink, updateProposalStatus } from '@/lib/identity/reconciliation/apply-link'
@@ -18,7 +16,7 @@ export async function POST(request: Request, { params }: Params) {
   if (!tenant) return errorResponse || NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { proposalId } = await params
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
   const resolvedBy = session?.user?.email || 'admin'
 
   try {

--- a/src/app/api/admin/invite/route.ts
+++ b/src/app/api/admin/invite/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { ROLE_CODES } from '@/config/role-codes'
 import { generateToken, storeToken } from '@/lib/auth-tokens'
 import { sendEmail } from '@/lib/email/delivery'
@@ -10,7 +8,7 @@ import { runGreenhousePostgresQuery, withGreenhousePostgresTransaction } from '@
 
 export async function POST(request: Request) {
   try {
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     if (!session?.user?.roleCodes?.includes(ROLE_CODES.EFEONCE_ADMIN)) {
       return NextResponse.json({ error: 'Acceso denegado.' }, { status: 403 })

--- a/src/app/api/admin/team/assignments/[assignmentId]/route.ts
+++ b/src/app/api/admin/team/assignments/[assignmentId]/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { deleteAssignment, getAdminTeamAssignmentDetail, toTeamAdminErrorResponse, updateAssignment } from '@/lib/team-admin/mutate-team'
 import { requireAdminTenantContext } from '@/lib/tenant/authorization'
 import type { UpdateAssignmentInput } from '@/types/team'
@@ -41,7 +39,7 @@ export async function PATCH(request: Request, context: { params: Promise<{ assig
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const updated = await updateAssignment({
       assignmentId,
@@ -65,7 +63,7 @@ export async function DELETE(_request: Request, context: { params: Promise<{ ass
 
   try {
     const { assignmentId } = await context.params
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const deleted = await deleteAssignment({
       assignmentId,

--- a/src/app/api/admin/team/assignments/route.ts
+++ b/src/app/api/admin/team/assignments/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { createAssignment, getAdminTeamAssignmentsPayload, toTeamAdminErrorResponse } from '@/lib/team-admin/mutate-team'
 import { requireAdminTenantContext } from '@/lib/tenant/authorization'
 import type { CreateAssignmentInput } from '@/types/team'
@@ -43,7 +41,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const created = await createAssignment({
       input: body,

--- a/src/app/api/admin/team/members/[memberId]/deactivate/route.ts
+++ b/src/app/api/admin/team/members/[memberId]/deactivate/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { deactivateMember, toTeamAdminErrorResponse } from '@/lib/team-admin/mutate-team'
 import { requireAdminTenantContext } from '@/lib/tenant/authorization'
 
@@ -17,7 +15,7 @@ export async function POST(_request: Request, context: { params: Promise<{ membe
 
   try {
     const { memberId } = await context.params
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const updated = await deactivateMember({
       memberId,

--- a/src/app/api/admin/team/members/[memberId]/route.ts
+++ b/src/app/api/admin/team/members/[memberId]/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { getAdminTeamMemberDetail, toTeamAdminErrorResponse, updateMember } from '@/lib/team-admin/mutate-team'
 import { requireAdminTenantContext } from '@/lib/tenant/authorization'
 import type { UpdateMemberInput } from '@/types/team'
@@ -41,7 +39,7 @@ export async function PATCH(request: Request, context: { params: Promise<{ membe
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const updated = await updateMember({
       memberId,

--- a/src/app/api/admin/team/members/route.ts
+++ b/src/app/api/admin/team/members/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { createMember, getAdminTeamMembersPayload, toTeamAdminErrorResponse } from '@/lib/team-admin/mutate-team'
 import { requireAdminTenantContext } from '@/lib/tenant/authorization'
 import type { CreateMemberInput } from '@/types/team'
@@ -39,7 +37,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const created = await createMember({
       input: body,

--- a/src/app/api/admin/users/[id]/resend-onboarding/route.ts
+++ b/src/app/api/admin/users/[id]/resend-onboarding/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { generateToken, storeToken } from '@/lib/auth-tokens'
 import { sendEmail } from '@/lib/email/delivery'
 import { runGreenhousePostgresQuery } from '@/lib/postgres/client'
@@ -77,7 +75,7 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
     const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL || 'https://greenhouse.efeoncepro.com'}/auth/accept-invite?token=${token}`
 
     // Get inviter name from session
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
     const inviterName = session?.user?.name || 'Un administrador'
     const actorEmail = session?.user?.email || undefined
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,22 @@
+import { NextResponse } from 'next/server'
+
 import NextAuth from 'next-auth'
 
-import { authOptions } from '@/lib/auth'
+import { getAuthOptions, isMissingNextAuthSecretError } from '@/lib/auth'
 
-const handler = NextAuth(authOptions)
+const handler = async (request: Request, context: { params: Promise<{ nextauth: string[] }> }) => {
+  try {
+    return await NextAuth(getAuthOptions())(request, context)
+  } catch (error) {
+    if (isMissingNextAuthSecretError(error)) {
+      return NextResponse.json(
+        { error: 'Authentication is not configured in this environment.' },
+        { status: 503 }
+      )
+    }
+
+    throw error
+  }
+}
 
 export { handler as GET, handler as POST }

--- a/src/app/api/home/nexa/feedback/route.ts
+++ b/src/app/api/home/nexa/feedback/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import type { NexaFeedbackRequest, NexaFeedbackResponse } from '@/lib/nexa/nexa-contract'
 import { persistNexaFeedback } from '@/lib/nexa/store'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: Request) {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/home/nexa/route.ts
+++ b/src/app/api/home/nexa/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
 import { resolveNexaModel } from '@/config/nexa-models'
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { resolveCapabilityModules } from '@/lib/capabilities/resolve-capabilities'
 import { canSeeFinanceStatus, getHomeFinanceStatus } from '@/lib/home/get-home-snapshot'
 import type { NexaRuntimeContext } from '@/lib/nexa/nexa-contract'
@@ -19,7 +17,7 @@ export const dynamic = 'force-dynamic'
  * getHomeSnapshot() to avoid blocking on notifications/DB per message.
  */
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/home/nexa/threads/[threadId]/route.ts
+++ b/src/app/api/home/nexa/threads/[threadId]/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { getNexaThreadDetail } from '@/lib/nexa/store'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(_: Request, context: { params: Promise<{ threadId: string }> }) {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/home/nexa/threads/route.ts
+++ b/src/app/api/home/nexa/threads/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { listNexaThreads } from '@/lib/nexa/store'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/home/snapshot/route.ts
+++ b/src/app/api/home/snapshot/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { getHomeSnapshot } from '@/lib/home/get-home-snapshot'
 
 /**
  * API route to fetch the initial data for the Greenhouse Home view.
  */
 export async function GET() {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/hr/payroll/compensation/[versionId]/route.ts
+++ b/src/app/api/hr/payroll/compensation/[versionId]/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { toPayrollErrorResponse } from '@/lib/payroll/api-response'
 import { updateCompensationVersion } from '@/lib/payroll/get-compensation'
 import { assertPayrollDateString, parsePayrollNumber } from '@/lib/payroll/shared'
@@ -25,7 +23,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ ve
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
     const { versionId } = await params
 
     const updated = await updateCompensationVersion({

--- a/src/app/api/hr/payroll/compensation/route.ts
+++ b/src/app/api/hr/payroll/compensation/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { createCompensationVersion, getCompensationOverview } from '@/lib/payroll/get-compensation'
 import { toPayrollErrorResponse } from '@/lib/payroll/api-response'
 import { assertPayrollDateString, parsePayrollNumber } from '@/lib/payroll/shared'
@@ -41,7 +39,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const created = await createCompensationVersion({
       input: {

--- a/src/app/api/hr/payroll/entries/[entryId]/route.ts
+++ b/src/app/api/hr/payroll/entries/[entryId]/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { recalculatePayrollEntry } from '@/lib/payroll/recalculate-entry'
 import { toPayrollErrorResponse } from '@/lib/payroll/api-response'
 import { normalizeNullableString, parsePayrollNumber } from '@/lib/payroll/shared'
@@ -20,7 +18,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ en
   try {
     const { entryId } = await params
     const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     if (!body) {
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })

--- a/src/app/api/hr/payroll/periods/[periodId]/approve/route.ts
+++ b/src/app/api/hr/payroll/periods/[periodId]/approve/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { getBigQueryProjectId } from '@/lib/bigquery'
 import { getPayrollEntries } from '@/lib/payroll/get-payroll-entries'
 import { getPayrollPeriod } from '@/lib/payroll/get-payroll-periods'
@@ -67,7 +65,7 @@ export async function POST(_: Request, { params }: { params: Promise<{ periodId:
       })
     }
 
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
     const actorIdentifier = session?.user?.email || tenant.userId
 
     if (isPayrollPostgresEnabled()) {

--- a/src/app/api/hr/payroll/periods/[periodId]/calculate/route.ts
+++ b/src/app/api/hr/payroll/periods/[periodId]/calculate/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { calculatePayroll } from '@/lib/payroll/calculate-payroll'
 import { toPayrollErrorResponse } from '@/lib/payroll/api-response'
 import { requireHrTenantContext } from '@/lib/tenant/authorization'
@@ -17,7 +15,7 @@ export async function POST(_: Request, { params }: { params: Promise<{ periodId:
   }
 
   try {
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
     const { periodId } = await params
 
     const result = await calculatePayroll({

--- a/src/app/api/hr/payroll/projected/promote/route.ts
+++ b/src/app/api/hr/payroll/projected/promote/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { toPayrollErrorResponse } from '@/lib/payroll/api-response'
 import { promoteProjectedPayrollToOfficialDraft } from '@/lib/payroll/promote-projected-payroll'
 import { requireHrTenantContext } from '@/lib/tenant/authorization'
@@ -24,7 +22,7 @@ export async function POST(request: Request) {
 
   try {
     const body = (await request.json().catch(() => ({}))) as PromoteBody
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     const year = Number(body.year)
     const month = Number(body.month)

--- a/src/app/api/my/profile/route.ts
+++ b/src/app/api/my/profile/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { requireTenantContext } from '@/lib/tenant/authorization'
 import {
   getPersonProfileByMemberId,
@@ -30,7 +28,7 @@ export async function GET() {
     }
 
     // Fallback: session always has name, email, avatar for authenticated users
-    const session = await getServerSession(authOptions)
+    const session = await getServerAuthSession()
 
     return NextResponse.json(toPersonProfileSummaryFromSession(session!.user))
   } catch (error) {

--- a/src/app/auth/landing/page.tsx
+++ b/src/app/auth/landing/page.tsx
@@ -1,11 +1,9 @@
 import { redirect } from 'next/navigation'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 
 export default async function Page() {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     redirect('/login')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,9 @@
 import { redirect } from 'next/navigation'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 
 export default async function Page() {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     redirect('/login')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import type { NextAuthOptions } from 'next-auth'
+import { getServerSession, type NextAuthOptions } from 'next-auth'
 import AzureADProvider from 'next-auth/providers/azure-ad'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import GoogleProvider from 'next-auth/providers/google'
@@ -26,13 +26,6 @@ import {
 import { resolvePortalHomePath } from '@/lib/tenant/resolve-portal-home-path'
 import { publishOutboxEvent } from '@/lib/sync/publish-event'
 import { AGGREGATE_TYPES, EVENT_TYPES } from '@/lib/sync/event-catalog'
-
-const microsoftClientId = process.env.AZURE_AD_CLIENT_ID
-const microsoftClientSecret = getAzureAdClientSecret()
-const googleClientId = process.env.GOOGLE_CLIENT_ID
-const googleClientSecret = getGoogleClientSecret()
-const hasMicrosoftProvider = hasMicrosoftAuthProvider()
-const hasGoogleProvider = hasGoogleAuthProvider()
 
 const getMicrosoftProfileIdentity = ({
   profile,
@@ -74,6 +67,30 @@ const getMicrosoftProfileIdentity = ({
     displayName,
     givenName,
     familyName
+  }
+}
+
+export const getAuthOptions = () => createAuthOptions()
+
+export const isMissingNextAuthSecretError = (error: unknown) =>
+  error instanceof Error && error.message === 'NEXTAUTH_SECRET is not set'
+
+let hasLoggedMissingNextAuthSecret = false
+
+export const getServerAuthSession = async () => {
+  try {
+    return await getServerSession(getAuthOptions())
+  } catch (error) {
+    if (isMissingNextAuthSecretError(error)) {
+      if (!hasLoggedMissingNextAuthSecret) {
+        console.warn('[auth] NEXTAUTH_SECRET is not set; treating request as unauthenticated in this runtime.')
+        hasLoggedMissingNextAuthSecret = true
+      }
+
+      return null
+    }
+
+    throw error
   }
 }
 
@@ -132,139 +149,147 @@ const getRejectedTenantMatchRedirect = async ({
   return '/auth/access-denied'
 }
 
-export const authOptions: NextAuthOptions = {
-  secret: getNextAuthSecret(),
-  session: {
-    strategy: 'jwt'
-  },
-  pages: {
-    signIn: '/login',
-    error: '/auth/access-denied'
-  },
-  providers: [
-    ...(hasMicrosoftProvider
-      ? [
-          AzureADProvider({
-            clientId: microsoftClientId!,
-            clientSecret: microsoftClientSecret!,
-            tenantId: 'common',
-            authorization: {
-              params: {
-                scope: 'openid profile email'
+const createAuthOptions = (): NextAuthOptions => {
+  const microsoftClientId = process.env.AZURE_AD_CLIENT_ID
+  const microsoftClientSecret = getAzureAdClientSecret()
+  const googleClientId = process.env.GOOGLE_CLIENT_ID
+  const googleClientSecret = getGoogleClientSecret()
+  const hasMicrosoftProvider = hasMicrosoftAuthProvider()
+  const hasGoogleProvider = hasGoogleAuthProvider()
+
+  return {
+    secret: getNextAuthSecret(),
+    session: {
+      strategy: 'jwt'
+    },
+    pages: {
+      signIn: '/login',
+      error: '/auth/access-denied'
+    },
+    providers: [
+      ...(hasMicrosoftProvider
+        ? [
+            AzureADProvider({
+              clientId: microsoftClientId!,
+              clientSecret: microsoftClientSecret!,
+              tenantId: 'common',
+              authorization: {
+                params: {
+                  scope: 'openid profile email'
+                }
               }
-            }
-          })
-        ]
-      : []),
-    ...(hasGoogleProvider
-      ? [
-          GoogleProvider({
-            clientId: googleClientId!,
-            clientSecret: googleClientSecret!,
-            authorization: {
-              params: {
-                scope: 'openid email'
+            })
+          ]
+        : []),
+      ...(hasGoogleProvider
+        ? [
+            GoogleProvider({
+              clientId: googleClientId!,
+              clientSecret: googleClientSecret!,
+              authorization: {
+                params: {
+                  scope: 'openid email'
+                }
               }
-            }
-          })
-        ]
-      : []),
-    CredentialsProvider({
-      name: 'Greenhouse Credentials',
-      credentials: {
-        email: { label: 'Email', type: 'email' },
-        password: { label: 'Password', type: 'password' }
-      },
-      async authorize(credentials) {
-        if (!credentials?.email || !credentials.password) {
-          return null
-        }
+            })
+          ]
+        : []),
+      CredentialsProvider({
+        name: 'Greenhouse Credentials',
+        credentials: {
+          email: { label: 'Email', type: 'email' },
+          password: { label: 'Password', type: 'password' }
+        },
+        async authorize(credentials) {
+          if (!credentials?.email || !credentials.password) {
+            return null
+          }
 
-        const normalizedEmail = credentials.email.trim().toLowerCase()
+          const normalizedEmail = credentials.email.trim().toLowerCase()
 
-        let tenant = null
+          let tenant = null
 
-        try {
-          tenant = await getTenantAccessRecordByEmail(normalizedEmail)
-        } catch (error) {
-          console.error('Credentials auth lookup failed.', { email: normalizedEmail }, error)
+          try {
+            tenant = await getTenantAccessRecordByEmail(normalizedEmail)
+          } catch (error) {
+            console.error('Credentials auth lookup failed.', { email: normalizedEmail }, error)
 
-          return null
-        }
+            return null
+          }
 
-        if (!tenant) {
-          console.warn('Credentials auth rejected: tenant user not found.', { email: normalizedEmail })
+          if (!tenant) {
+            console.warn('Credentials auth rejected: tenant user not found.', { email: normalizedEmail })
 
-          return null
-        }
+            return null
+          }
 
-        const isValidPassword = await verifyTenantPassword(tenant, credentials.password)
+          const isValidPassword = await verifyTenantPassword(tenant, credentials.password)
 
-        if (!isValidPassword) {
-          console.warn('Credentials auth rejected: password mismatch or inactive user.', {
-            email: normalizedEmail,
+          if (!isValidPassword) {
+            console.warn('Credentials auth rejected: password mismatch or inactive user.', {
+              email: normalizedEmail,
+              userId: tenant.userId,
+              active: tenant.active,
+              status: tenant.status
+            })
+
+            // Audit: emit login.failed (TASK-248)
+            publishOutboxEvent({
+              aggregateType: AGGREGATE_TYPES.authSession,
+              aggregateId: tenant.userId,
+              eventType: EVENT_TYPES.loginFailed,
+              payload: { email: normalizedEmail, provider: 'credentials', reason: 'invalid_password' }
+            }).catch(() => {})
+
+            return null
+          }
+
+          try {
+            await updateTenantLastLogin(tenant, 'credentials')
+          } catch (error) {
+            console.warn('Unable to update tenant last_login_at after successful auth.', error)
+          }
+
+          return {
+            id: tenant.userId,
+            email: tenant.email,
+            name: tenant.fullName,
+            avatarUrl: tenant.avatarUrl,
             userId: tenant.userId,
-            active: tenant.active,
-            status: tenant.status
-          })
+            clientId: tenant.clientId,
+            clientName: tenant.clientName,
+            tenantType: tenant.tenantType,
+            roleCodes: tenant.roleCodes,
+            primaryRoleCode: tenant.primaryRoleCode,
+            routeGroups: tenant.routeGroups,
+            authorizedViews: tenant.authorizedViews,
+            projectScopes: tenant.projectScopes,
+            campaignScopes: tenant.campaignScopes,
+            businessLines: tenant.businessLines,
+            serviceModules: tenant.serviceModules,
+            projectIds: tenant.projectIds,
+            role: tenant.role,
+            featureFlags: tenant.featureFlags,
+            timezone: tenant.timezone,
+            portalHomePath: tenant.portalHomePath,
+            authMode: tenant.authMode,
+            provider: 'credentials',
+            microsoftEmail: tenant.microsoftEmail,
+            googleEmail: tenant.googleEmail,
 
-          // Audit: emit login.failed (TASK-248)
-          publishOutboxEvent({
-            aggregateType: AGGREGATE_TYPES.authSession,
-            aggregateId: tenant.userId,
-            eventType: EVENT_TYPES.loginFailed,
-            payload: { email: normalizedEmail, provider: 'credentials', reason: 'invalid_password' }
-          }).catch(() => {})
+            // Account 360
+            spaceId: tenant.spaceId ?? undefined,
+            organizationId: tenant.organizationId ?? undefined,
+            organizationName: tenant.organizationName ?? undefined,
 
-          return null
+            // Collaborator identity
+            memberId: tenant.memberId ?? undefined,
+            identityProfileId: tenant.identityProfileId ?? undefined
+          }
         }
-
-        try {
-          await updateTenantLastLogin(tenant, 'credentials')
-        } catch (error) {
-          console.warn('Unable to update tenant last_login_at after successful auth.', error)
-        }
-
-        return {
-          id: tenant.userId,
-          email: tenant.email,
-          name: tenant.fullName,
-          avatarUrl: tenant.avatarUrl,
-          userId: tenant.userId,
-          clientId: tenant.clientId,
-          clientName: tenant.clientName,
-          tenantType: tenant.tenantType,
-          roleCodes: tenant.roleCodes,
-          primaryRoleCode: tenant.primaryRoleCode,
-          routeGroups: tenant.routeGroups,
-          authorizedViews: tenant.authorizedViews,
-          projectScopes: tenant.projectScopes,
-          campaignScopes: tenant.campaignScopes,
-          businessLines: tenant.businessLines,
-          serviceModules: tenant.serviceModules,
-          projectIds: tenant.projectIds,
-          role: tenant.role,
-          featureFlags: tenant.featureFlags,
-          timezone: tenant.timezone,
-          portalHomePath: tenant.portalHomePath,
-          authMode: tenant.authMode,
-          provider: 'credentials',
-          microsoftEmail: tenant.microsoftEmail,
-          googleEmail: tenant.googleEmail,
-
-          // Account 360
-          spaceId: tenant.spaceId ?? undefined,
-          organizationId: tenant.organizationId ?? undefined,
-          organizationName: tenant.organizationName ?? undefined,
-
-          // Collaborator identity
-          memberId: tenant.memberId ?? undefined,
-          identityProfileId: tenant.identityProfileId ?? undefined
-        }
-      }
-    })
-  ],
-  callbacks: {
+      })
+    ],
+    callbacks: {
     async signIn({ user, account, profile }) {
       if (account?.provider === 'credentials') {
         return true
@@ -606,4 +631,5 @@ export const authOptions: NextAuthOptions = {
       }
     }
   }
+}
 }

--- a/src/lib/tenant/get-tenant-context.ts
+++ b/src/lib/tenant/get-tenant-context.ts
@@ -1,8 +1,6 @@
 import 'server-only'
 
-import { getServerSession } from 'next-auth'
-
-import { authOptions } from '@/lib/auth'
+import { getServerAuthSession } from '@/lib/auth'
 import { getCachedBusinessLineSummaries } from '@/lib/business-line/metadata'
 import type { BusinessLineMetadataSummary } from '@/types/business-line'
 
@@ -40,7 +38,7 @@ export interface TenantContext {
 }
 
 export const getTenantContext = async (): Promise<TenantContext | null> => {
-  const session = await getServerSession(authOptions)
+  const session = await getServerAuthSession()
 
   if (!session?.user) {
     return null


### PR DESCRIPTION
## Summary
- harden NextAuth setup so preview builds do not fail at import-time when NEXTAUTH_SECRET is missing
- route server-side session consumers through a lazy helper that degrades to unauthenticated instead of aborting page-data collection
- document the resolved Vercel Preview incident as ISSUE-031

## Validation
- pnpm build
- pnpm lint
- pnpm build with only .vercel/.env.preview.local loaded (no .env.local / .env.production.local)
