### PR TITLE
docs: capture resolved preview baseline drift

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,35 @@
 # Handoff.md
 
+## Sesion 2026-04-08 — ISSUE-031 cerrado de punta a punta: Preview baseline ya no depende de overrides por branch
+
+- contexto:
+  - el hardening de auth ya habia cerrado el deploy blocker, pero faltaba confirmar si `Preview` seguia dependiendo de env vars atadas a `develop` y ramas historicas
+  - con `vercel` CLI autenticado se pudo inspeccionar el entorno efectivo real de una preview cualquiera
+- causa raiz operativa confirmada:
+  - el `Preview` generico resolvia casi solo `NUBOX_*` + variables internas de Vercel
+  - auth, GCP, PostgreSQL, media buckets y `AGENT_AUTH_*` estaban mayormente como overrides por branch (`develop` u otras ramas), no como baseline generico de `Preview`
+  - por eso una branch nueva podia buildar con drift severo aunque `develop` pareciera sano
+- fix operativo aplicado en Vercel:
+  - se forzaron overrides genericos `preview` para:
+    - `AGENT_AUTH_EMAIL`, `AGENT_AUTH_SECRET`
+    - `AZURE_AD_CLIENT_ID`, `AZURE_AD_CLIENT_SECRET`
+    - `GCP_PROJECT`, `GCP_SERVICE_ACCOUNT_EMAIL`, `GCP_WORKLOAD_IDENTITY_PROVIDER`
+    - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+    - `GREENHOUSE_MEDIA_BUCKET`, `GREENHOUSE_PRIVATE_ASSETS_BUCKET`, `GREENHOUSE_PUBLIC_MEDIA_BUCKET`
+    - `GREENHOUSE_POSTGRES_DATABASE`, `GREENHOUSE_POSTGRES_HOST`, `GREENHOUSE_POSTGRES_INSTANCE_CONNECTION_NAME`, `GREENHOUSE_POSTGRES_IP_TYPE`, `GREENHOUSE_POSTGRES_MAX_CONNECTIONS`, `GREENHOUSE_POSTGRES_PASSWORD`, `GREENHOUSE_POSTGRES_SSL`, `GREENHOUSE_POSTGRES_USER`
+    - `NEXTAUTH_SECRET`, `NEXTAUTH_URL`
+    - `WEBHOOK_NOTIFICATIONS_SECRET_SECRET_REF`
+  - `GOOGLE_APPLICATION_CREDENTIALS_JSON` no se forzo porque el baseline local actual lo lleva vacio; el runtime queda cubierto por WIF (`GCP_*` + `VERCEL_OIDC_TOKEN`)
+- validacion operativa ejecutada:
+  - `vercel env pull --environment preview --git-branch fix/codex-preview-baseline-smoke` — ya resuelve `NEXTAUTH_*`, `GCP_*`, `GOOGLE_CLIENT_*`, `GREENHOUSE_POSTGRES_*` y `AGENT_AUTH_*`
+  - preview fresco desplegado: `https://greenhouse-mi5qiomu5-efeonce-7670142f.vercel.app`
+  - `GET /api/auth/session` en ese preview — `200 {}` (ya no `503`)
+  - `POST /api/auth/agent-session` con el usuario agente — `200`, devolviendo `cookieName`, `cookieValue`, `portalHomePath`, `userId`
+- documentacion a mantener alineada:
+  - `docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md`
+  - `project_context.md`
+  - `changelog.md`
+
 ## Sesion 2026-04-08 — ISSUE-031 resolved: Vercel Preview build no longer dies on missing NEXTAUTH_SECRET
 
 - contexto:

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 - Se resolvió el incidente donde los Preview Deployments de Vercel quedaban en `Error` por `NEXTAUTH_SECRET` faltante durante `page-data collection`.
 - `src/lib/auth.ts` pasó a resolver `NextAuthOptions` de forma lazy y los consumers server-side ahora usan `getServerAuthSession()`.
 - Si un runtime carece de `NEXTAUTH_SECRET`, el build ya no se cae: el portal degrada a sesión `null` y `/api/auth/[...nextauth]` responde `503` controlado.
+- Seguimiento operativo: el baseline genérico de `Preview` en Vercel quedó alineado para ramas nuevas con `NEXTAUTH_*`, Google/Azure auth, PostgreSQL, media buckets y `AGENT_AUTH_*`, evitando depender de overrides por branch como baseline compartido.
+- Validación posterior: un preview fresco ya respondió `200 {}` en `/api/auth/session` y `200` en `/api/auth/agent-session`.
 - El incidente quedó documentado como `ISSUE-031`.
 
 ### 2026-04-08 — Hotfix productivo Banco: materializacion de balances corregida

--- a/docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md
+++ b/docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md
@@ -25,11 +25,21 @@ Error: Failed to collect page data for /api/admin/invite
 
 ## Causa raíz
 
-El ambiente `Preview` de Vercel tenía drift respecto del baseline local y compartido:
+La causa real tenía dos capas:
 
-- faltaba `NEXTAUTH_SECRET`
-- faltaba `NEXTAUTH_URL`
-- también faltaban `GCP_PROJECT` y `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+- el `Preview` genérico de Vercel no tenía baseline compartido de auth/runtime
+- varias variables críticas estaban definidas solo como overrides por branch (`develop` u otras ramas históricas), por lo que ramas nuevas no las heredaban
+
+El entorno efectivo de una preview nueva resolvía solo un set mínimo (`NUBOX_*` y variables internas de Vercel) y dejaba afuera, al menos:
+
+- `NEXTAUTH_SECRET`
+- `NEXTAUTH_URL`
+- `GCP_PROJECT`
+- `GCP_SERVICE_ACCOUNT_EMAIL`
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GREENHOUSE_POSTGRES_*`
 
 El fallo que rompía el deployment aparecía primero en `NEXTAUTH_SECRET` porque `src/lib/auth.ts` resolvía `authOptions` en import-time. Durante `page-data collection`, Next importaba routes y páginas que llamaban `getServerSession(authOptions)`, por lo que el build abortaba antes de terminar.
 
@@ -41,6 +51,10 @@ El fallo que rompía el deployment aparecía primero en `NEXTAUTH_SECRET` porque
 
 ## Solución
 
+Se resolvió por dos carriles complementarios.
+
+### 1. Hardening de aplicación
+
 Se endureció el carril de auth para que el drift de Preview no vuelva a bloquear el build:
 
 - `src/lib/auth.ts` ahora construye `NextAuthOptions` de forma lazy (`getAuthOptions()`) en vez de hacerlo al importar el módulo.
@@ -48,7 +62,21 @@ Se endureció el carril de auth para que el drift de Preview no vuelva a bloquea
 - Si falta `NEXTAUTH_SECRET`, `getServerAuthSession()` degrada a sesión `null` en vez de romper el build.
 - `src/app/api/auth/[...nextauth]/route.ts` ahora responde `503` controlado cuando la autenticación no está configurada en ese runtime, en vez de explotar durante import-time.
 
-Esto no reemplaza la política operativa de Vercel: un Preview que necesite login real sigue debiendo tener `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GCP_PROJECT` y credenciales Google válidas. Pero el deployment deja de caer silenciosamente por ese drift.
+### 2. Alineación operativa de Vercel Preview
+
+Se dejó creado un baseline genérico de `Preview` para ramas nuevas, en vez de seguir dependiendo de overrides por branch:
+
+- auth: `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `AZURE_AD_CLIENT_ID`, `AZURE_AD_CLIENT_SECRET`
+- runtime GCP: `GCP_PROJECT`, `GCP_SERVICE_ACCOUNT_EMAIL`, `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- runtime PostgreSQL: `GREENHOUSE_POSTGRES_DATABASE`, `GREENHOUSE_POSTGRES_HOST`, `GREENHOUSE_POSTGRES_INSTANCE_CONNECTION_NAME`, `GREENHOUSE_POSTGRES_IP_TYPE`, `GREENHOUSE_POSTGRES_MAX_CONNECTIONS`, `GREENHOUSE_POSTGRES_PASSWORD`, `GREENHOUSE_POSTGRES_SSL`, `GREENHOUSE_POSTGRES_USER`
+- baseline funcional: `GREENHOUSE_MEDIA_BUCKET`, `GREENHOUSE_PRIVATE_ASSETS_BUCKET`, `GREENHOUSE_PUBLIC_MEDIA_BUCKET`
+- acceso headless: `AGENT_AUTH_EMAIL`, `AGENT_AUTH_SECRET`
+- referencia de webhook: `WEBHOOK_NOTIFICATIONS_SECRET_SECRET_REF`
+
+Regla operativa consolidada:
+
+- el hardening evita que el deployment quede rojo si vuelve a existir drift
+- pero el baseline genérico de `Preview` ya no debe depender de overrides por branch para auth, DB o acceso de agente
 
 ## Verificación
 
@@ -65,6 +93,22 @@ La reproducción aislada confirmó el before/after:
 
 - antes del fix: `NEXTAUTH_SECRET is not set` durante `page-data collection`
 - después del fix: el build de `Preview` completa
+
+Validación operativa posterior en Vercel:
+
+- `vercel env pull --environment preview --git-branch fix/codex-preview-baseline-smoke` ya resuelve para una branch cualquiera:
+  - `NEXTAUTH_SECRET`
+  - `NEXTAUTH_URL`
+  - `GCP_PROJECT`
+  - `GCP_SERVICE_ACCOUNT_EMAIL`
+  - `GCP_WORKLOAD_IDENTITY_PROVIDER`
+  - `GOOGLE_CLIENT_ID`
+  - `GOOGLE_CLIENT_SECRET`
+  - `GREENHOUSE_POSTGRES_*`
+  - `AGENT_AUTH_*`
+- se desplegó un preview fresco y:
+  - `GET /api/auth/session` respondió `200` con body `{}` en vez de `503`
+  - `POST /api/auth/agent-session` respondió `200` y devolvió `cookieName`, `cookieValue`, `portalHomePath`, `userId`
 
 ## Estado
 

--- a/project_context.md
+++ b/project_context.md
@@ -10,6 +10,10 @@
 - Regla operativa vigente:
   - el hardening evita que el deployment quede rojo por drift
   - pero un Preview que necesite login funcional sigue debiendo tener `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GCP_PROJECT` y credenciales Google válidas
+- Cierre operativo 2026-04-08:
+  - el baseline genérico de `Preview` ya quedó alineado en Vercel para ramas nuevas
+  - auth, Google/Azure, PostgreSQL, media buckets y `AGENT_AUTH_*` no deben seguir dependiendo de overrides por branch como baseline compartido
+  - validación runtime: un preview fresco ya responde `200` en `/api/auth/session` y `200` en `/api/auth/agent-session`
 - Issue resuelto de referencia: `docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md`
 
 ## Delta 2026-04-07 Account Complete 360 — serving federado por facetas (TASK-274)


### PR DESCRIPTION
## Summary
- expand ISSUE-031 with the full Vercel Preview root cause and final remediation
- document that Preview now has a generic baseline instead of relying on branch-specific overrides
- record runtime verification for /api/auth/session and /api/auth/agent-session on a fresh preview deployment

## Validation
- vercel env pull --environment preview --git-branch fix/codex-preview-baseline-smoke
- vercel deploy preview smoke: /api/auth/session -> 200 {}
- vercel deploy preview smoke: /api/auth/agent-session -> 200
