### PR TITLE
docs: codify preview baseline protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,32 @@ Este repositorio es la base operativa de Greenhouse sobre Vuexy + Next.js. Aqui 
 - Si se define un dominio de staging, debe apuntar al `Custom Environment` de `develop`, no a ramas personales.
 - No usar Production como entorno de prueba manual.
 
+### Protocolo canonico de Preview
+
+- Regla base: `Preview` debe considerarse **el entorno compartido y genérico para cualquier rama que no sea `develop` ni `main`**.
+- Interpretación operativa:
+  - `develop` valida en `Staging`
+  - `main` valida en `Production`
+  - toda rama `feature/*`, `fix/*`, `hotfix/*`, `docs/*` o equivalente valida en `Preview`
+- Consecuencia obligatoria: una branch nueva debe poder desplegar en `Preview` **sin depender** de que antes exista `Preview (develop)` o `Preview (<otra-rama>)`.
+- Las variables críticas de runtime para ramas de trabajo deben existir como baseline de `Preview` genérico, no solo como override por branch.
+- Los overrides `Preview (<branch>)` quedan permitidos solo como excepción temporal cuando:
+  - una rama necesita un valor distinto al baseline compartido
+  - el caso está documentado en `Handoff.md` y, si aplica, en un issue o task
+  - existe plan explícito de limpieza al cerrar la rama
+- Regla dura: no usar `Preview (develop)` como source of truth de secrets para el resto de las ramas. Si una variable es necesaria para una preview nueva, debe promoverse a `Preview` genérico.
+- Antes de dar por sano un cambio que dependa de variables nuevas, verificar el baseline efectivo con una branch cualquiera, no solo con `develop`.
+- Smoke check canónico de baseline:
+  - `vercel env pull --environment preview --git-branch <branch-cualquiera>`
+  - confirmar que el set mínimo requerido aparece sin depender de overrides históricos
+- Familias de variables que no deben quedar solo en overrides por branch cuando afectan el runtime base de previews:
+  - auth (`NEXTAUTH_*`, `GOOGLE_CLIENT_*`, `AZURE_AD_*`)
+  - acceso GCP (`GCP_*`, credenciales o WIF equivalente)
+  - PostgreSQL (`GREENHOUSE_POSTGRES_*`)
+  - acceso headless/agentes (`AGENT_AUTH_*`)
+  - correo, webhooks o cron si el flujo requiere esas capacidades en previews
+- Si aparece una preview roja en una rama nueva pero `develop` sigue sano, asumir primero drift de env por overrides de branch antes de culpar al diff.
+
 ### Vercel Deployment Protection (SSO)
 
 - El proyecto tiene **Vercel Authentication (SSO)** habilitada con `deploymentType: "all_except_custom_domains"`.
@@ -237,6 +263,12 @@ Este repositorio es la base operativa de Greenhouse sobre Vuexy + Next.js. Aqui 
   - `Staging`: branch `develop`
   - `Production`: solo main
 - No crear una variable solo en Production si el cambio necesita validacion previa en Preview o Staging.
+- No dejar variables críticas solo en `Preview (develop)` o `Preview (<branch>)` si el comportamiento esperado debe existir para cualquier rama de trabajo.
+- Regla de provisioning:
+  - `Preview` genérico es el baseline para ramas no `develop`/`main`
+  - `Staging` es el baseline de `develop`
+  - `Production` es el baseline de `main`
+  - los overrides por branch son aditivos o excepcionales, no la fuente primaria del contrato
 - Toda variable nueva debe indicar:
   - nombre
   - proposito

--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,18 @@
 # Handoff.md
 
+## Sesion 2026-04-08 — Protocolo nuevo: Preview es baseline genérico para ramas distintas de develop/main
+
+- se documentó en `AGENTS.md` y docs operativos que:
+  - `Preview` es el baseline genérico para cualquier rama distinta de `develop` y `main`
+  - `Staging` es el baseline compartido de `develop`
+  - `Production` es el baseline de `main`
+  - `Preview (develop)` y `Preview (<branch>)` no pueden seguir siendo source of truth del runtime base
+- regla nueva:
+  - los overrides por branch quedan permitidos solo como excepción temporal y documentada
+  - si una variable es necesaria para previews normales, debe vivir en `Preview` genérico
+- motivación:
+  - evitar que ramas nuevas hereden un preview casi vacío y generen cascadas de failures en GitHub/Vercel por drift acumulado de env vars
+
 ## Sesion 2026-04-08 — ISSUE-031 cerrado de punta a punta: Preview baseline ya no depende de overrides por branch
 
 - contexto:

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Si un runtime carece de `NEXTAUTH_SECRET`, el build ya no se cae: el portal degrada a sesión `null` y `/api/auth/[...nextauth]` responde `503` controlado.
 - Seguimiento operativo: el baseline genérico de `Preview` en Vercel quedó alineado para ramas nuevas con `NEXTAUTH_*`, Google/Azure auth, PostgreSQL, media buckets y `AGENT_AUTH_*`, evitando depender de overrides por branch como baseline compartido.
 - Validación posterior: un preview fresco ya respondió `200 {}` en `/api/auth/session` y `200` en `/api/auth/agent-session`.
+- Nuevo protocolo operativo: `Preview` pasa a tratarse explícitamente como baseline genérico para cualquier rama distinta de `develop` y `main`; los overrides por branch quedan solo como excepción temporal y documentada.
 - El incidente quedó documentado como `ISSUE-031`.
 
 ### 2026-04-08 — Hotfix productivo Banco: materializacion de balances corregida

--- a/docs/operations/GREENHOUSE_CLOUD_GOVERNANCE_OPERATING_MODEL_V1.md
+++ b/docs/operations/GREENHOUSE_CLOUD_GOVERNANCE_OPERATING_MODEL_V1.md
@@ -202,6 +202,26 @@ Each Cloud concern must have a canonical home.
 - Cloud SQL PITR and flags
 - secret storage decisions
 - deploy validation expectations
+- preview baseline ownership and cleanup rules for branch overrides
+
+### 5.2.1 Preview baseline rule
+
+For Vercel in Greenhouse:
+
+- `Preview` is the generic non-`develop`, non-`main` runtime baseline
+- `Staging` is the `develop` baseline
+- `Production` is the `main` baseline
+
+This means:
+
+- branch previews must inherit a usable baseline without relying on `Preview (develop)` or another branch override
+- branch-specific preview vars are temporary exceptions, not the canonical contract
+- if a value is required for normal preview runtime across working branches, it belongs in generic `Preview`
+
+Operational guardrail:
+
+- when investigating new preview failures, check the effective env for an arbitrary branch before assuming code regression
+- if a key only exists in `Preview (develop)` or `Preview (<branch>)` but is needed by ordinary previews, promote it to generic `Preview` and document the cleanup
 
 ### 5.3 May live in UI as a mirror
 

--- a/docs/operations/RELEASE_CHANNELS_OPERATING_MODEL_V1.md
+++ b/docs/operations/RELEASE_CHANNELS_OPERATING_MODEL_V1.md
@@ -117,6 +117,21 @@ Uso recomendado:
 - exploración interna
 - validación técnica o UX temprana
 
+Reglas operativas obligatorias:
+
+- `Preview` es el ambiente canónico para cualquier rama que no sea `develop` ni `main`.
+- `Preview` no debe depender de `Preview (develop)` ni de overrides históricos por branch para su runtime base.
+- Toda capacidad o fix que necesite validación remota en ramas de trabajo debe poder desplegar con el baseline genérico de `Preview`.
+- Los overrides `Preview (<branch>)` solo se permiten como excepción temporal y documentada; no reemplazan el baseline compartido.
+- Si una rama nueva falla en preview mientras `develop` funciona, el primer diagnóstico debe ser drift de variables por branch antes de asumir regressión de código.
+
+Baseline mínimo esperado para `Preview` cuando aplica login/runtime completo:
+
+- auth compartida (`NEXTAUTH_*`, `GOOGLE_CLIENT_*`, `AZURE_AD_*`)
+- acceso cloud/runtime (`GCP_*` o mecanismo equivalente)
+- acceso de datos (`GREENHOUSE_POSTGRES_*`)
+- acceso headless/agente (`AGENT_AUTH_*`)
+
 Canal típico:
 
 - `alpha`

--- a/project_context.md
+++ b/project_context.md
@@ -14,6 +14,10 @@
   - el baseline genérico de `Preview` ya quedó alineado en Vercel para ramas nuevas
   - auth, Google/Azure, PostgreSQL, media buckets y `AGENT_AUTH_*` no deben seguir dependiendo de overrides por branch como baseline compartido
   - validación runtime: un preview fresco ya responde `200` en `/api/auth/session` y `200` en `/api/auth/agent-session`
+- Regla operativa nueva:
+  - `Preview` debe tratarse siempre como baseline genérico para toda rama distinta de `develop` y `main`
+  - `Preview (develop)` no puede seguir funcionando como source of truth del resto de previews
+  - los overrides por branch quedan solo como excepción temporal y documentada
 - Issue resuelto de referencia: `docs/issues/resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md`
 
 ## Delta 2026-04-07 Account Complete 360 — serving federado por facetas (TASK-274)


### PR DESCRIPTION
## Summary
- document that Preview is the generic baseline for any branch other than develop/main
- ban using Preview (develop) or other branch overrides as the source of truth for normal preview runtime
- record the cleanup rule: branch-specific preview env vars are temporary exceptions only

## Notes
- docs-only change
- no code/runtime changes in this PR
