### PR TITLE
[codex] seed kortex sister-platform pilot

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,29 @@
 # Handoff.md
 
+## Sesion 2026-04-11 — Seed operativo Kortex pilot READY
+
+- alcance implementado:
+  - helper nuevo `src/lib/sister-platforms/consumers.ts`
+    - lista consumers
+    - crea consumer con token hasheado
+    - upsert idempotente por `sister_platform_key + consumer_name`
+    - rotacion opcional de token
+  - script nuevo `scripts/seed-kortex-sister-platform-pilot.ts`
+  - comando nuevo `pnpm seed:kortex-pilot`
+  - docs actualizados:
+    - `docs/architecture/GREENHOUSE_SISTER_PLATFORM_BINDINGS_RUNTIME_V1.md`
+    - `docs/documentation/plataforma/sister-platform-bindings.md`
+- contrato operativo:
+  - el seed provisiona o actualiza el consumer dedicado de Kortex y su binding `portal -> Greenhouse scope`
+  - defaults seguros:
+    - consumer `active`
+    - binding `draft`
+    - allowed scopes `client,space`
+  - el token solo aparece cuando se crea o se rota (`KORTEX_ROTATE_CONSUMER_TOKEN=true`)
+- siguiente accion natural:
+  - correr `pnpm seed:kortex-pilot` con IDs reales del piloto y guardar el token emitido en los secrets del runtime Kortex
+  - luego hacer smoke call a `/api/integrations/v1/sister-platforms/context`
+
 ## Sesion 2026-04-11 — local Next build isolation ACTIVADA para evitar colisiones entre agentes
 
 - alcance implementado:

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ## 2026-04-11
 
+### 2026-04-11 — Seed operativo para el piloto Kortex sobre sister-platform consumers
+
+- Se agregó `src/lib/sister-platforms/consumers.ts` para provisionar y actualizar credenciales dedicadas de sister platforms con token hasheado y rotación opcional.
+- Se agregó `scripts/seed-kortex-sister-platform-pilot.ts` y el comando `pnpm seed:kortex-pilot`.
+- El seed deja listo el primer carril operativo Kortex-side en Greenhouse:
+  - consumer dedicado `Kortex Operator Console`
+  - binding `kortex` con `external_scope_type='portal'`
+  - defaults seguros (`binding=draft`, `consumer=active`, `allowed scopes=client,space`)
+- El token solo se vuelve a imprimir cuando el consumer se crea o cuando se solicita una rotación explícita.
+
 ### 2026-04-11 — Local Next builds pasan a usar output aislado fuera de Vercel/CI
 
 - `pnpm build` ya no reutiliza `.next` por defecto en local; ahora usa `.next-local/build-<timestamp>-<pid>` mediante `scripts/next-dist-dir.mjs`.

--- a/docs/architecture/GREENHOUSE_SISTER_PLATFORM_BINDINGS_RUNTIME_V1.md
+++ b/docs/architecture/GREENHOUSE_SISTER_PLATFORM_BINDINGS_RUNTIME_V1.md
@@ -27,6 +27,7 @@ Current runtime status:
 - admin read/governance surface implemented
 - hardened read-only sister-platform lane implemented under `/api/integrations/v1/sister-platforms/*`
 - per-consumer credential model implemented in code + migration file
+- consumer provisioning helper + Kortex pilot seed script implemented in code
 - request logging and rate limiting implemented in code + migration file
 - migrations applied on 2026-04-11 via `pnpm pg:connect:migrate`
 - generated DB types regenerated in `src/types/db.d.ts`
@@ -293,9 +294,11 @@ Resolver policy:
 ### Files
 
 - `src/lib/sister-platforms/external-auth.ts`
+- `src/lib/sister-platforms/consumers.ts`
 - `src/app/api/integrations/v1/sister-platforms/context/route.ts`
 - `src/app/api/integrations/v1/sister-platforms/catalog/capabilities/route.ts`
 - `src/app/api/integrations/v1/sister-platforms/readiness/route.ts`
+- `scripts/seed-kortex-sister-platform-pilot.ts`
 
 ### Request contract
 
@@ -320,6 +323,52 @@ Required query params:
 | `GET` | `/api/integrations/v1/sister-platforms/context` | Resolve consumer + active binding context |
 | `GET` | `/api/integrations/v1/sister-platforms/catalog/capabilities` | Export capability catalog through the hardened lane |
 | `GET` | `/api/integrations/v1/sister-platforms/readiness?keys=...` | Export readiness posture through the hardened lane |
+
+## Consumer Provisioning
+
+### Runtime helper
+
+`src/lib/sister-platforms/consumers.ts`
+
+Responsibilities:
+
+- list existing consumer credentials
+- create a consumer credential with hashed token storage
+- upsert an existing consumer credential by `(sister_platform_key, consumer_name)`
+- rotate the token only when explicitly requested
+- preserve consumer governance metadata and scope allowlist
+
+### Current operational script
+
+`scripts/seed-kortex-sister-platform-pilot.ts`
+
+Entrypoint:
+
+- `pnpm seed:kortex-pilot`
+
+What it does:
+
+1. provisions or updates the dedicated Kortex consumer
+2. provisions or updates the primary `portal` binding for the selected Greenhouse scope
+3. prints a fresh token only when the credential is created or rotated
+4. keeps the binding idempotent so operators can rerun it safely
+
+Minimum env for the script:
+
+- `KORTEX_EXTERNAL_SCOPE_ID`
+- `KORTEX_GREENHOUSE_SCOPE_TYPE`
+- `KORTEX_GREENHOUSE_ORGANIZATION_ID`
+
+Additional env depending on scope:
+
+- `KORTEX_GREENHOUSE_CLIENT_ID` for `client` / `space`
+- `KORTEX_GREENHOUSE_SPACE_ID` for `space`
+
+Safe defaults:
+
+- binding status defaults to `draft`
+- consumer status defaults to `active`
+- allowed scopes default to `client,space`
 
 ## Events
 
@@ -381,12 +430,16 @@ What it does not do yet:
 - expose MCP read operations
 - implement any Kortex-specific bridge logic
 
-Those belong to `TASK-377`.
+What it now does for Kortex specifically:
+- seeds the first dedicated Kortex consumer credential
+- seeds the first primary Kortex `portal -> Greenhouse scope` binding
+
+The bridge logic itself still belongs to `TASK-377` and the Kortex repo follow-on.
 
 ## Known Gaps
 
 1. no dedicated consumer exists yet for the new outbox events
-2. admin UI is visibility-first; it is not yet a full operator workflow
+2. admin UI is visibility-first; it is not yet a full operator workflow for consumer rotation
 
 ## File Map
 
@@ -397,16 +450,19 @@ Those belong to `TASK-377`.
 | runtime types | `src/lib/sister-platforms/types.ts` |
 | runtime helper | `src/lib/sister-platforms/bindings.ts` |
 | runtime helper | `src/lib/sister-platforms/external-auth.ts` |
+| runtime helper | `src/lib/sister-platforms/consumers.ts` |
 | admin API list/create | `src/app/api/admin/integrations/sister-platform-bindings/route.ts` |
 | admin API detail/update | `src/app/api/admin/integrations/sister-platform-bindings/[bindingId]/route.ts` |
 | external API context | `src/app/api/integrations/v1/sister-platforms/context/route.ts` |
 | external API catalog | `src/app/api/integrations/v1/sister-platforms/catalog/capabilities/route.ts` |
 | external API readiness | `src/app/api/integrations/v1/sister-platforms/readiness/route.ts` |
+| operational script | `scripts/seed-kortex-sister-platform-pilot.ts` |
 | admin UI wiring | `src/app/(dashboard)/admin/integrations/page.tsx` |
 | admin UI section | `src/views/greenhouse/admin/AdminIntegrationGovernanceView.tsx` |
 | event catalog | `src/lib/sync/event-catalog.ts` |
 
 ## Next Steps
 
-1. implement the first Kortex bridge in `TASK-377`
-2. add a dedicated downstream consumer for the binding lifecycle events when a concrete integration needs them
+1. run `pnpm seed:kortex-pilot` with the real pilot IDs and store the emitted token in Kortex runtime secrets
+2. implement the first Kortex bridge in `TASK-377`
+3. add a dedicated downstream consumer for the binding lifecycle events when a concrete integration needs them

--- a/docs/documentation/plataforma/sister-platform-bindings.md
+++ b/docs/documentation/plataforma/sister-platform-bindings.md
@@ -3,7 +3,7 @@
 > **Tipo de documento:** Documentacion funcional (lenguaje simple)
 > **Version:** 1.0
 > **Creado:** 2026-04-11 por Codex (TASK-375)
-> **Ultima actualizacion:** 2026-04-11 por Codex (TASK-376)
+> **Ultima actualizacion:** 2026-04-11 por Codex (Kortex pilot seed follow-up)
 > **Documentacion tecnica:** `docs/architecture/GREENHOUSE_SISTER_PLATFORM_BINDINGS_RUNTIME_V1.md`
 
 ---
@@ -55,6 +55,10 @@ La API read-only nueva permite:
 - resolver el binding activo de un scope externo
 - leer el catalogo y la readiness sin usar el token compartido generico
 - dejar request logging y rate limiting sobre ese carril
+
+Tambien existe ahora un seed operativo para dejar listo el primer consumer Kortex sin crear registros a mano:
+
+- `pnpm seed:kortex-pilot`
 
 ## Que estados puede tener
 
@@ -134,10 +138,41 @@ Esas piezas vienen despues en:
 Regla simple:
 
 - primero se crea o corrige el binding
+- en el caso de Kortex piloto, se crea o actualiza tambien su consumer dedicado con `pnpm seed:kortex-pilot`
 - despues se activa
 - solo entonces una integracion externa deberia apoyarse en ese enlace
 
 Si hay duda sobre el scope correcto, no corresponde activar el binding "para probar". Debe quedar en `draft` hasta validar la relacion real.
+
+## Seed piloto Kortex
+
+El seed operativo del piloto Kortex hace dos cosas juntas:
+
+1. crea o actualiza el consumer `Kortex Operator Console`
+2. crea o actualiza el binding `kortex -> portal`
+
+Variables minimas para correrlo:
+
+- `KORTEX_EXTERNAL_SCOPE_ID`
+- `KORTEX_GREENHOUSE_SCOPE_TYPE`
+- `KORTEX_GREENHOUSE_ORGANIZATION_ID`
+
+Y segun el scope:
+
+- `KORTEX_GREENHOUSE_CLIENT_ID` para `client` o `space`
+- `KORTEX_GREENHOUSE_SPACE_ID` para `space`
+
+Defaults operativos:
+
+- binding en `draft`
+- consumer en `active`
+- scopes permitidos `client,space`
+
+El script es idempotente:
+
+- si el consumer existe, lo actualiza
+- si el binding existe, lo actualiza
+- solo imprime token nuevo cuando lo crea o cuando se pide rotacion
 
 ## Quien deberia tocarlo
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "setup:postgres:staff-augmentation": "tsx scripts/setup-postgres-staff-augmentation.ts",
     "setup:postgres:transactional-email": "tsx scripts/setup-postgres-transactional-email.ts",
     "setup:postgres:view-access": "tsx scripts/setup-postgres-view-access.ts",
+    "seed:kortex-pilot": "tsx scripts/seed-kortex-sister-platform-pilot.ts",
     "staging:request": "node scripts/staging-request.mjs",
     "email:dev": "email dev --dir src/emails --port 3001",
     "postinstall": "npm run build:icons",

--- a/project_context.md
+++ b/project_context.md
@@ -39,6 +39,19 @@
   - la migración quedó aplicada el 2026-04-11 vía `pnpm pg:connect:migrate`
   - `src/types/db.d.ts` quedó regenerado en el mismo lote
 
+## Delta 2026-04-11 Seed operativo para consumer piloto Kortex
+
+- Greenhouse ya tiene una utilidad operativa para provisionar el primer consumer Kortex y su binding piloto sin SQL manual.
+- Runtime nuevo:
+  - helper `src/lib/sister-platforms/consumers.ts`
+  - script `scripts/seed-kortex-sister-platform-pilot.ts`
+  - comando `pnpm seed:kortex-pilot`
+- Contrato operativo:
+  - el seed crea o actualiza el consumer dedicado `Kortex Operator Console`
+  - el seed crea o actualiza el binding `kortex` con `external_scope_type='portal'`
+  - el token solo se imprime cuando se crea o rota; no se reexpone en ejecuciones normales
+  - defaults seguros: binding `draft`, consumer `active`, scopes permitidos `client,space`
+
 ## Delta 2026-04-11 Foundation runtime para sister-platform bindings
 
 - Greenhouse ya tiene una foundation runtime explícita para bindear sister platforms con scopes internos.

--- a/scripts/seed-kortex-sister-platform-pilot.ts
+++ b/scripts/seed-kortex-sister-platform-pilot.ts
@@ -1,0 +1,305 @@
+import { closeGreenhousePostgres } from '@/lib/db'
+import {
+  createSisterPlatformBinding,
+  listSisterPlatformBindings,
+  updateSisterPlatformBinding
+} from '@/lib/sister-platforms/bindings'
+import { upsertSisterPlatformConsumer } from '@/lib/sister-platforms/consumers'
+import type {
+  CreateSisterPlatformBindingInput,
+  SisterPlatformBindingRecord,
+  SisterPlatformBindingStatus,
+  SisterPlatformGreenhouseScopeType
+} from '@/lib/sister-platforms/types'
+
+import { applyGreenhousePostgresProfile, loadGreenhouseToolEnv } from './lib/load-greenhouse-tool-env'
+
+type ScopeInput = {
+  greenhouseScopeType: SisterPlatformGreenhouseScopeType
+  organizationId: string | null
+  clientId: string | null
+  spaceId: string | null
+}
+
+const readEnv = (key: string) => {
+  const value = process.env[key]?.trim()
+
+  
+return value ? value : null
+}
+
+const readPositiveInt = (key: string, fallback: number) => {
+  const raw = readEnv(key)
+
+  if (!raw) {
+    return fallback
+  }
+
+  const value = Number(raw)
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${key} debe ser un numero positivo.`)
+  }
+
+  return Math.trunc(value)
+}
+
+const readCsvScopes = (key: string, fallback: SisterPlatformGreenhouseScopeType[]) => {
+  const raw = readEnv(key)
+
+  if (!raw) {
+    return fallback
+  }
+
+  const values = raw
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+    .filter(
+      (item): item is SisterPlatformGreenhouseScopeType =>
+        item === 'organization' || item === 'client' || item === 'space' || item === 'internal'
+    )
+
+  if (values.length === 0) {
+    throw new Error(`${key} debe incluir al menos un scope valido.`)
+  }
+
+  return Array.from(new Set(values))
+}
+
+const readBindingStatus = () => {
+  const status = readEnv('KORTEX_BINDING_STATUS') ?? 'draft'
+
+  if (status !== 'draft' && status !== 'active' && status !== 'suspended' && status !== 'deprecated') {
+    throw new Error('KORTEX_BINDING_STATUS debe ser draft, active, suspended o deprecated.')
+  }
+
+  return status as SisterPlatformBindingStatus
+}
+
+const readScopeInput = (): ScopeInput => {
+  const greenhouseScopeType = (readEnv('KORTEX_GREENHOUSE_SCOPE_TYPE') ?? 'client') as SisterPlatformGreenhouseScopeType
+  const organizationId = readEnv('KORTEX_GREENHOUSE_ORGANIZATION_ID')
+  const clientId = readEnv('KORTEX_GREENHOUSE_CLIENT_ID')
+  const spaceId = readEnv('KORTEX_GREENHOUSE_SPACE_ID')
+
+  if (
+    greenhouseScopeType !== 'organization' &&
+    greenhouseScopeType !== 'client' &&
+    greenhouseScopeType !== 'space' &&
+    greenhouseScopeType !== 'internal'
+  ) {
+    throw new Error('KORTEX_GREENHOUSE_SCOPE_TYPE debe ser organization, client, space o internal.')
+  }
+
+  if (greenhouseScopeType === 'internal') {
+    if (organizationId || clientId || spaceId) {
+      throw new Error('Scope internal no acepta organization/client/space ids.')
+    }
+
+    return {
+      greenhouseScopeType,
+      organizationId: null,
+      clientId: null,
+      spaceId: null
+    }
+  }
+
+  if (!organizationId) {
+    throw new Error('KORTEX_GREENHOUSE_ORGANIZATION_ID es requerido para organization/client/space.')
+  }
+
+  if (greenhouseScopeType === 'organization') {
+    return {
+      greenhouseScopeType,
+      organizationId,
+      clientId: null,
+      spaceId: null
+    }
+  }
+
+  if (!clientId) {
+    throw new Error('KORTEX_GREENHOUSE_CLIENT_ID es requerido para client/space.')
+  }
+
+  if (greenhouseScopeType === 'client') {
+    return {
+      greenhouseScopeType,
+      organizationId,
+      clientId,
+      spaceId: null
+    }
+  }
+
+  if (!spaceId) {
+    throw new Error('KORTEX_GREENHOUSE_SPACE_ID es requerido para space.')
+  }
+
+  return {
+    greenhouseScopeType,
+    organizationId,
+    clientId,
+    spaceId
+  }
+}
+
+const resolveExistingBinding = async (externalScopeId: string) => {
+  const bindings = await listSisterPlatformBindings({
+    sisterPlatformKey: 'kortex',
+    limit: 200
+  })
+
+  return (
+    bindings.find(
+      binding =>
+        binding.externalScopeType === 'portal' &&
+        binding.externalScopeId === externalScopeId &&
+        binding.bindingRole === 'primary'
+    ) ?? null
+  )
+}
+
+const upsertKortexBinding = async (input: CreateSisterPlatformBindingInput) => {
+  const existingBinding = await resolveExistingBinding(input.externalScopeId)
+
+  if (!existingBinding) {
+    const createdBinding = await createSisterPlatformBinding({ input })
+
+    return {
+      binding: createdBinding,
+      created: true
+    }
+  }
+
+  const updatedBinding = await updateSisterPlatformBinding({
+    bindingId: existingBinding.bindingId,
+    input: {
+      externalScopeParentId: input.externalScopeParentId ?? null,
+      externalDisplayName: input.externalDisplayName ?? null,
+      greenhouseScopeType: input.greenhouseScopeType,
+      organizationId: input.organizationId ?? null,
+      clientId: input.clientId ?? null,
+      spaceId: input.spaceId ?? null,
+      bindingStatus: input.bindingStatus,
+      notes: input.notes ?? null,
+      metadata: input.metadata ?? {},
+      lastVerifiedAt: input.lastVerifiedAt ?? null
+    }
+  })
+
+  return {
+    binding: updatedBinding,
+    created: false
+  }
+}
+
+const printBindingSummary = (binding: SisterPlatformBindingRecord) => {
+  console.log('')
+  console.log('Binding listo:')
+  console.log(`- publicId: ${binding.publicId}`)
+  console.log(`- status: ${binding.bindingStatus}`)
+  console.log(`- external: ${binding.externalScopeType}:${binding.externalScopeId}`)
+  console.log(
+    `- greenhouseScope: ${binding.greenhouseScopeType} (org=${binding.organizationId ?? '-'}, client=${binding.clientId ?? '-'}, space=${binding.spaceId ?? '-'})`
+  )
+}
+
+async function main() {
+  loadGreenhouseToolEnv()
+  applyGreenhousePostgresProfile('runtime')
+
+  const externalScopeId = readEnv('KORTEX_EXTERNAL_SCOPE_ID')
+  const externalDisplayName = readEnv('KORTEX_EXTERNAL_DISPLAY_NAME')
+  const externalScopeParentId = readEnv('KORTEX_EXTERNAL_SCOPE_PARENT_ID')
+  const installationId = readEnv('KORTEX_INSTALLATION_ID')
+  const actorUserId = readEnv('KORTEX_ACTOR_USER_ID') ?? 'system'
+  const rotateToken = readEnv('KORTEX_ROTATE_CONSUMER_TOKEN') === 'true'
+  const providedToken = readEnv('KORTEX_CONSUMER_TOKEN')
+  const bindingStatus = readBindingStatus()
+  const allowedGreenhouseScopeTypes = readCsvScopes('KORTEX_ALLOWED_GREENHOUSE_SCOPE_TYPES', ['client', 'space'])
+  const scope = readScopeInput()
+
+  if (!externalScopeId) {
+    throw new Error('KORTEX_EXTERNAL_SCOPE_ID es requerido. Usa el portal_id o hubspot_portal_id canonico.')
+  }
+
+  const consumerResult = await upsertSisterPlatformConsumer({
+    sisterPlatformKey: 'kortex',
+    consumerName: readEnv('KORTEX_CONSUMER_NAME') ?? 'Kortex Operator Console',
+    consumerType: 'sister_platform',
+    credentialStatus: readEnv('KORTEX_CONSUMER_STATUS') === 'draft' ? 'draft' : 'active',
+    token: providedToken ?? undefined,
+    rotateToken,
+    allowedGreenhouseScopeTypes,
+    rateLimitPerMinute: readPositiveInt('KORTEX_RATE_LIMIT_PER_MINUTE', 60),
+    rateLimitPerHour: readPositiveInt('KORTEX_RATE_LIMIT_PER_HOUR', 1000),
+    notes: readEnv('KORTEX_NOTES') ?? 'Seed operativo del piloto Kortex desde Greenhouse.',
+    metadata: {
+      source: 'scripts/seed-kortex-sister-platform-pilot.ts',
+      installationId,
+      externalScopeType: 'portal',
+      externalScopeId,
+      taskId: 'TASK-377'
+    },
+    actorUserId
+  })
+
+  const bindingResult = await upsertKortexBinding({
+    sisterPlatformKey: 'kortex',
+    externalScopeType: 'portal',
+    externalScopeId,
+    externalScopeParentId,
+    externalDisplayName,
+    greenhouseScopeType: scope.greenhouseScopeType,
+    organizationId: scope.organizationId,
+    clientId: scope.clientId,
+    spaceId: scope.spaceId,
+    bindingRole: 'primary',
+    bindingStatus,
+    notes: readEnv('KORTEX_BINDING_NOTES') ?? 'Binding piloto Kortex -> Greenhouse.',
+    metadata: {
+      source: 'scripts/seed-kortex-sister-platform-pilot.ts',
+      installationId,
+      externalScopeType: 'portal',
+      externalScopeId,
+      taskId: 'TASK-377'
+    },
+    lastVerifiedAt: new Date().toISOString()
+  })
+
+  console.log('Kortex pilot seed completado.')
+  console.log('')
+  console.log('Consumer listo:')
+  console.log(`- publicId: ${consumerResult.consumer.publicId}`)
+  console.log(`- status: ${consumerResult.consumer.credentialStatus}`)
+  console.log(`- tokenPrefix: ${consumerResult.consumer.tokenPrefix}`)
+  console.log(`- allowedScopes: ${consumerResult.consumer.allowedGreenhouseScopeTypes.join(', ')}`)
+  console.log(`- mode: ${consumerResult.created ? 'created' : 'updated'}${consumerResult.rotated ? ' + token rotated' : ''}`)
+
+  if (consumerResult.plainToken) {
+    console.log('')
+    console.log('Token nuevo/rotado (guardalo en el runtime de Kortex):')
+    console.log(consumerResult.plainToken)
+  } else {
+    console.log('')
+    console.log('Token no rotado. Se reutilizo la credencial existente.')
+  }
+
+  printBindingSummary(bindingResult.binding)
+
+  console.log('')
+  console.log('Smoke call sugerido:')
+  console.log(
+    `curl \"$GREENHOUSE_BASE_URL/api/integrations/v1/sister-platforms/context?externalScopeType=portal&externalScopeId=${encodeURIComponent(externalScopeId)}\" -H \"x-greenhouse-sister-platform-key: <TOKEN_KORTEX>\"`
+  )
+}
+
+main()
+  .catch(error => {
+    console.error('Kortex pilot seed fallo.')
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await closeGreenhousePostgres().catch(() => {})
+  })

--- a/src/lib/hr-core/postgres-leave-store.test.ts
+++ b/src/lib/hr-core/postgres-leave-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import type { TenantContext } from '@/lib/tenant/get-tenant-context'
 
 vi.mock('server-only', () => ({}))

--- a/src/lib/sister-platforms/consumers.ts
+++ b/src/lib/sister-platforms/consumers.ts
@@ -1,0 +1,511 @@
+import 'server-only'
+
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
+
+import { query, withTransaction } from '@/lib/db'
+
+import type {
+  CreateSisterPlatformConsumerInput,
+  SisterPlatformConsumerRecord,
+  SisterPlatformConsumerStatus,
+  SisterPlatformConsumerType,
+  SisterPlatformGreenhouseScopeType,
+  UpsertSisterPlatformConsumerInput
+} from './types'
+
+type SisterPlatformConsumerRow = {
+  consumer_id: string
+  public_id: string
+  sister_platform_key: string
+  consumer_name: string
+  consumer_type: SisterPlatformConsumerType
+  credential_status: SisterPlatformConsumerStatus
+  token_prefix: string
+  hash_algorithm: 'sha256'
+  allowed_greenhouse_scope_types: string[] | null
+  rate_limit_per_minute: number
+  rate_limit_per_hour: number
+  expires_at: string | Date | null
+  last_used_at: string | Date | null
+  notes: string | null
+  metadata_json: Record<string, unknown> | null
+  created_by_user_id: string | null
+  rotated_by_user_id: string | null
+  suspended_by_user_id: string | null
+  deprecated_by_user_id: string | null
+  suspended_at: string | Date | null
+  deprecated_at: string | Date | null
+  created_at: string | Date
+  updated_at: string | Date
+}
+
+type TransactionClient = {
+  query: (text: string, values?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }>
+}
+
+export class SisterPlatformConsumerError extends Error {
+  statusCode: number
+
+  constructor(message: string, statusCode = 400) {
+    super(message)
+    this.name = 'SisterPlatformConsumerError'
+    this.statusCode = statusCode
+  }
+}
+
+const ALL_SCOPE_TYPES: SisterPlatformGreenhouseScopeType[] = ['organization', 'client', 'space', 'internal']
+
+const toIsoString = (value: string | Date | null) => {
+  if (!value) return null
+  if (typeof value === 'string') return value
+
+  return value.toISOString()
+}
+
+const sanitizeOptionalText = (value: unknown) => {
+  if (typeof value !== "string") return null
+
+  const normalized = value.trim()
+
+  return normalized.length > 0 ? normalized : null
+}
+
+const sanitizeRequiredText = (value: unknown, fieldName: string) => {
+  const normalized = sanitizeOptionalText(value)
+
+  if (!normalized) {
+    throw new SisterPlatformConsumerError(`${fieldName} es requerido.`)
+  }
+
+  return normalized
+}
+
+const sanitizeJson = (value: Record<string, unknown> | null | undefined) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  return value
+}
+
+const normalizeScopeTypes = (value: SisterPlatformGreenhouseScopeType[] | undefined) => {
+  if (!value || value.length === 0) {
+    return [...ALL_SCOPE_TYPES]
+  }
+
+  const normalized = Array.from(new Set(value)).filter(
+    (item): item is SisterPlatformGreenhouseScopeType =>
+      item === 'organization' || item === 'client' || item === 'space' || item === 'internal'
+  )
+
+  if (normalized.length === 0) {
+    throw new SisterPlatformConsumerError('allowedGreenhouseScopeTypes debe incluir al menos un scope valido.')
+  }
+
+  return normalized
+}
+
+const normalizeLimit = (value: number | undefined, fieldName: string, fallback: number) => {
+  if (value === undefined || value === null) {
+    return fallback
+  }
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new SisterPlatformConsumerError(`${fieldName} debe ser un numero positivo.`)
+  }
+
+  return Math.trunc(value)
+}
+
+const normalizeIsoTimestamp = (value: string | null | undefined, fieldName: string) => {
+  if (!value) {
+    return null
+  }
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new SisterPlatformConsumerError(`${fieldName} debe ser un timestamp ISO valido.`)
+  }
+
+  return parsed.toISOString()
+}
+
+const mapConsumerRow = (row: SisterPlatformConsumerRow): SisterPlatformConsumerRecord => ({
+  consumerId: row.consumer_id,
+  publicId: row.public_id,
+  sisterPlatformKey: row.sister_platform_key,
+  consumerName: row.consumer_name,
+  consumerType: row.consumer_type,
+  credentialStatus: row.credential_status,
+  tokenPrefix: row.token_prefix,
+  hashAlgorithm: row.hash_algorithm,
+  allowedGreenhouseScopeTypes: normalizeScopeTypes(row.allowed_greenhouse_scope_types as SisterPlatformGreenhouseScopeType[]),
+  rateLimitPerMinute: Number(row.rate_limit_per_minute || 0),
+  rateLimitPerHour: Number(row.rate_limit_per_hour || 0),
+  expiresAt: toIsoString(row.expires_at),
+  lastUsedAt: toIsoString(row.last_used_at),
+  notes: row.notes,
+  metadata: row.metadata_json ?? {},
+  createdByUserId: row.created_by_user_id,
+  rotatedByUserId: row.rotated_by_user_id,
+  suspendedByUserId: row.suspended_by_user_id,
+  deprecatedByUserId: row.deprecated_by_user_id,
+  suspendedAt: toIsoString(row.suspended_at),
+  deprecatedAt: toIsoString(row.deprecated_at),
+  createdAt: toIsoString(row.created_at) || new Date(0).toISOString(),
+  updatedAt: toIsoString(row.updated_at) || new Date(0).toISOString()
+})
+
+const loadConsumerById = async (consumerId: string) => {
+  const result = await query<SisterPlatformConsumerRow>(
+    `
+      SELECT
+        sister_platform_consumer_id AS consumer_id,
+        public_id,
+        sister_platform_key,
+        consumer_name,
+        consumer_type,
+        credential_status,
+        token_prefix,
+        hash_algorithm,
+        allowed_greenhouse_scope_types,
+        rate_limit_per_minute,
+        rate_limit_per_hour,
+        expires_at,
+        last_used_at,
+        notes,
+        metadata_json,
+        created_by_user_id,
+        rotated_by_user_id,
+        suspended_by_user_id,
+        deprecated_by_user_id,
+        suspended_at,
+        deprecated_at,
+        created_at,
+        updated_at
+      FROM greenhouse_core.sister_platform_consumers
+      WHERE sister_platform_consumer_id = $1
+      LIMIT 1
+    `,
+    [consumerId]
+  )
+
+  const row = (result as SisterPlatformConsumerRow[])[0]
+
+  return row ? mapConsumerRow(row) : null
+}
+
+const loadConsumerByIdentity = async (sisterPlatformKey: string, consumerName: string) => {
+  const result = await query<SisterPlatformConsumerRow>(
+    `
+      SELECT
+        sister_platform_consumer_id AS consumer_id,
+        public_id,
+        sister_platform_key,
+        consumer_name,
+        consumer_type,
+        credential_status,
+        token_prefix,
+        hash_algorithm,
+        allowed_greenhouse_scope_types,
+        rate_limit_per_minute,
+        rate_limit_per_hour,
+        expires_at,
+        last_used_at,
+        notes,
+        metadata_json,
+        created_by_user_id,
+        rotated_by_user_id,
+        suspended_by_user_id,
+        deprecated_by_user_id,
+        suspended_at,
+        deprecated_at,
+        created_at,
+        updated_at
+      FROM greenhouse_core.sister_platform_consumers
+      WHERE sister_platform_key = $1
+        AND lower(consumer_name) = lower($2)
+      ORDER BY updated_at DESC
+      LIMIT 1
+    `,
+    [sisterPlatformKey, consumerName]
+  )
+
+  const row = (result as SisterPlatformConsumerRow[])[0]
+
+  return row ? mapConsumerRow(row) : null
+}
+
+const nextConsumerPublicId = async (client: TransactionClient) => {
+  const result = await client.query(
+    `
+      SELECT
+        'EO-SPK-' || LPAD(nextval('greenhouse_core.seq_sister_platform_consumer_public_id')::text, 4, '0') AS public_id
+    `
+  )
+
+  const publicId = String(result.rows[0]?.public_id || '').trim()
+
+  if (!publicId) {
+    throw new SisterPlatformConsumerError('No fue posible generar public_id para el consumer.')
+  }
+
+  return publicId
+}
+
+const buildStatusFields = (credentialStatus: SisterPlatformConsumerStatus, actorUserId: string | null) => {
+  const now = new Date().toISOString()
+
+  return {
+    suspendedAt: credentialStatus === 'suspended' ? now : null,
+    deprecatedAt: credentialStatus === 'deprecated' ? now : null,
+    suspendedByUserId: credentialStatus === 'suspended' ? actorUserId : null,
+    deprecatedByUserId: credentialStatus === 'deprecated' ? actorUserId : null
+  }
+}
+
+export const buildSisterPlatformConsumerTokenHash = (token: string) => createHash('sha256').update(token).digest('hex')
+
+export const buildSisterPlatformConsumerTokenPrefix = (token: string) =>
+  buildSisterPlatformConsumerTokenHash(token).slice(0, 16)
+
+export const generateSisterPlatformConsumerToken = () => `ghspk_${randomBytes(32).toString('hex')}`
+
+export const listSisterPlatformConsumers = async (filters?: {
+  sisterPlatformKey?: string
+  credentialStatus?: SisterPlatformConsumerStatus
+  limit?: number
+}) => {
+  const values: unknown[] = []
+  const conditions: string[] = []
+
+  if (filters?.sisterPlatformKey) {
+    values.push(filters.sisterPlatformKey)
+    conditions.push(`sister_platform_key = $${values.length}`)
+  }
+
+  if (filters?.credentialStatus) {
+    values.push(filters.credentialStatus)
+    conditions.push(`credential_status = $${values.length}`)
+  }
+
+  const limit = Math.max(1, Math.min(filters?.limit ?? 100, 500))
+
+  values.push(limit)
+
+  const result = await query<SisterPlatformConsumerRow>(
+    `
+      SELECT
+        sister_platform_consumer_id AS consumer_id,
+        public_id,
+        sister_platform_key,
+        consumer_name,
+        consumer_type,
+        credential_status,
+        token_prefix,
+        hash_algorithm,
+        allowed_greenhouse_scope_types,
+        rate_limit_per_minute,
+        rate_limit_per_hour,
+        expires_at,
+        last_used_at,
+        notes,
+        metadata_json,
+        created_by_user_id,
+        rotated_by_user_id,
+        suspended_by_user_id,
+        deprecated_by_user_id,
+        suspended_at,
+        deprecated_at,
+        created_at,
+        updated_at
+      FROM greenhouse_core.sister_platform_consumers
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ORDER BY updated_at DESC, created_at DESC
+      LIMIT $${values.length}
+    `,
+    values
+  )
+
+  return (result as SisterPlatformConsumerRow[]).map(mapConsumerRow)
+}
+
+export const createSisterPlatformConsumer = async (input: CreateSisterPlatformConsumerInput) => {
+  const sisterPlatformKey = sanitizeRequiredText(input.sisterPlatformKey, 'sisterPlatformKey').toLowerCase()
+  const consumerName = sanitizeRequiredText(input.consumerName, 'consumerName')
+  const consumerType = input.consumerType ?? 'sister_platform'
+  const credentialStatus = input.credentialStatus ?? 'active'
+  const actorUserId = sanitizeOptionalText(input.actorUserId)
+  const token = sanitizeOptionalText(input.token) ?? generateSisterPlatformConsumerToken()
+  const allowedGreenhouseScopeTypes = normalizeScopeTypes(input.allowedGreenhouseScopeTypes)
+  const rateLimitPerMinute = normalizeLimit(input.rateLimitPerMinute, 'rateLimitPerMinute', 60)
+  const rateLimitPerHour = normalizeLimit(input.rateLimitPerHour, 'rateLimitPerHour', 1000)
+  const expiresAt = normalizeIsoTimestamp(input.expiresAt, 'expiresAt')
+  const notes = sanitizeOptionalText(input.notes)
+  const metadata = sanitizeJson(input.metadata)
+  const consumerId = `spc-${randomUUID()}`
+
+  const publicId = await withTransaction(async client => {
+    const generatedPublicId = await nextConsumerPublicId(client as TransactionClient)
+    const statusFields = buildStatusFields(credentialStatus, actorUserId)
+
+    await client.query(
+      `
+        INSERT INTO greenhouse_core.sister_platform_consumers (
+          sister_platform_consumer_id,
+          public_id,
+          sister_platform_key,
+          consumer_name,
+          consumer_type,
+          credential_status,
+          token_prefix,
+          token_hash,
+          hash_algorithm,
+          allowed_greenhouse_scope_types,
+          rate_limit_per_minute,
+          rate_limit_per_hour,
+          expires_at,
+          notes,
+          metadata_json,
+          created_by_user_id,
+          rotated_by_user_id,
+          suspended_by_user_id,
+          deprecated_by_user_id,
+          suspended_at,
+          deprecated_at
+        ) VALUES (
+          $1, $2, $3, $4, $5, $6, $7, $8, 'sha256', $9::text[], $10, $11, $12, $13, $14::jsonb, $15, NULL, $16, $17, $18, $19
+        )
+      `,
+      [
+        consumerId,
+        generatedPublicId,
+        sisterPlatformKey,
+        consumerName,
+        consumerType,
+        credentialStatus,
+        buildSisterPlatformConsumerTokenPrefix(token),
+        buildSisterPlatformConsumerTokenHash(token),
+        allowedGreenhouseScopeTypes,
+        rateLimitPerMinute,
+        rateLimitPerHour,
+        expiresAt,
+        notes,
+        JSON.stringify(metadata),
+        actorUserId,
+        statusFields.suspendedByUserId,
+        statusFields.deprecatedByUserId,
+        statusFields.suspendedAt,
+        statusFields.deprecatedAt
+      ]
+    )
+
+    return generatedPublicId
+  })
+
+  const createdConsumer = await loadConsumerById(consumerId)
+
+  if (!createdConsumer || createdConsumer.publicId !== publicId) {
+    throw new SisterPlatformConsumerError('No fue posible recargar el consumer recien creado.', 500)
+  }
+
+  return {
+    consumer: createdConsumer,
+    plainToken: token
+  }
+}
+
+export const upsertSisterPlatformConsumer = async (input: UpsertSisterPlatformConsumerInput) => {
+  const sisterPlatformKey = sanitizeRequiredText(input.sisterPlatformKey, 'sisterPlatformKey').toLowerCase()
+  const consumerName = sanitizeRequiredText(input.consumerName, 'consumerName')
+  const existing = await loadConsumerByIdentity(sisterPlatformKey, consumerName)
+
+  if (!existing) {
+    const created = await createSisterPlatformConsumer({
+      ...input,
+      sisterPlatformKey,
+      consumerName
+    })
+
+    return {
+      ...created,
+      created: true,
+      rotated: true
+    }
+  }
+
+  const credentialStatus = input.credentialStatus ?? existing.credentialStatus
+  const actorUserId = sanitizeOptionalText(input.actorUserId)
+  const rotateToken = input.rotateToken === true || Boolean(sanitizeOptionalText(input.token))
+  const token = rotateToken ? sanitizeOptionalText(input.token) ?? generateSisterPlatformConsumerToken() : null
+  const statusFields = buildStatusFields(credentialStatus, actorUserId)
+
+  const allowedGreenhouseScopeTypes = normalizeScopeTypes(
+    input.allowedGreenhouseScopeTypes ?? existing.allowedGreenhouseScopeTypes
+  )
+
+  const rateLimitPerMinute = normalizeLimit(input.rateLimitPerMinute, 'rateLimitPerMinute', existing.rateLimitPerMinute)
+  const rateLimitPerHour = normalizeLimit(input.rateLimitPerHour, 'rateLimitPerHour', existing.rateLimitPerHour)
+  const expiresAt = normalizeIsoTimestamp(input.expiresAt ?? existing.expiresAt, 'expiresAt')
+  const notes = input.notes === undefined ? existing.notes : sanitizeOptionalText(input.notes)
+  const metadata = input.metadata === undefined ? existing.metadata : sanitizeJson(input.metadata)
+  const consumerType = input.consumerType ?? existing.consumerType
+
+  await withTransaction(async client => {
+    await client.query(
+      `
+        UPDATE greenhouse_core.sister_platform_consumers
+        SET
+          consumer_type = $2,
+          credential_status = $3,
+          token_prefix = COALESCE($4, token_prefix),
+          token_hash = COALESCE($5, token_hash),
+          allowed_greenhouse_scope_types = $6::text[],
+          rate_limit_per_minute = $7,
+          rate_limit_per_hour = $8,
+          expires_at = $9,
+          notes = $10,
+          metadata_json = $11::jsonb,
+          rotated_by_user_id = CASE WHEN $4 IS NULL THEN rotated_by_user_id ELSE $12 END,
+          suspended_by_user_id = $13,
+          deprecated_by_user_id = $14,
+          suspended_at = $15,
+          deprecated_at = $16,
+          updated_at = NOW()
+        WHERE sister_platform_consumer_id = $1
+      `,
+      [
+        existing.consumerId,
+        consumerType,
+        credentialStatus,
+        token ? buildSisterPlatformConsumerTokenPrefix(token) : null,
+        token ? buildSisterPlatformConsumerTokenHash(token) : null,
+        allowedGreenhouseScopeTypes,
+        rateLimitPerMinute,
+        rateLimitPerHour,
+        expiresAt,
+        notes,
+        JSON.stringify(metadata),
+        token ? actorUserId : null,
+        statusFields.suspendedByUserId,
+        statusFields.deprecatedByUserId,
+        statusFields.suspendedAt,
+        statusFields.deprecatedAt
+      ]
+    )
+  })
+
+  const updatedConsumer = await loadConsumerById(existing.consumerId)
+
+  if (!updatedConsumer) {
+    throw new SisterPlatformConsumerError('No fue posible recargar el consumer actualizado.', 500)
+  }
+
+  return {
+    consumer: updatedConsumer,
+    plainToken: token,
+    created: false,
+    rotated: rotateToken
+  }
+}

--- a/src/lib/sister-platforms/types.ts
+++ b/src/lib/sister-platforms/types.ts
@@ -108,6 +108,25 @@ export type SisterPlatformConsumerRecord = {
   updatedAt: string
 }
 
+export type CreateSisterPlatformConsumerInput = {
+  sisterPlatformKey: string
+  consumerName: string
+  consumerType?: SisterPlatformConsumerType
+  credentialStatus?: SisterPlatformConsumerStatus
+  token?: string
+  allowedGreenhouseScopeTypes?: SisterPlatformGreenhouseScopeType[]
+  rateLimitPerMinute?: number
+  rateLimitPerHour?: number
+  expiresAt?: string | null
+  notes?: string | null
+  metadata?: Record<string, unknown> | null
+  actorUserId?: string | null
+}
+
+export type UpsertSisterPlatformConsumerInput = CreateSisterPlatformConsumerInput & {
+  rotateToken?: boolean
+}
+
 export type CreateSisterPlatformBindingInput = {
   sisterPlatformKey: string
   externalScopeType: SisterPlatformExternalScopeType


### PR DESCRIPTION
## What changed
- added a reusable sister-platform consumer helper for hashed token provisioning and rotation
- added `pnpm seed:kortex-pilot` to provision or update the Kortex pilot consumer plus its primary portal binding
- updated sister-platform runtime and operational docs for the new provisioning flow
- fixed the lingering `import/order` issue in `src/lib/hr-core/postgres-leave-store.test.ts` so lint stays green

## Why
TASK-377 defined the Greenhouse-side onboarding model for Kortex, but the repo still lacked the actual operator path to seed the dedicated consumer credential and pilot binding without manual SQL.

## Impact
- Greenhouse can now provision the first Kortex pilot consumer safely and idempotently
- token material is only printed on create or explicit rotation
- the next real-world step is to run the seed with the pilot IDs and store the emitted token in Kortex runtime secrets

## Validation
- `pnpm lint`
- `pnpm build`
- `rg -n "new Pool\(" src`
