### PR TITLE
fix(TASK-379): audit-only sweep in reactive consumer + recover endpoint

### DIFF
--- a/services/ops-worker/server.ts
+++ b/services/ops-worker/server.ts
@@ -19,7 +19,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 
-import { processReactiveEvents, ensureReactiveSchema } from '@/lib/sync/reactive-consumer'
+import { processReactiveEvents, ensureReactiveSchema, sweepAuditOnlyEvents } from '@/lib/sync/reactive-consumer'
 import { claimOrphanedRefreshItems, markRefreshCompleted, markRefreshFailed } from '@/lib/sync/refresh-queue'
 import { getRegisteredProjections } from '@/lib/sync/projection-registry'
 import { ensureProjectionsRegistered } from '@/lib/sync/projections'
@@ -207,15 +207,48 @@ const handleReactiveRecover = async (req: IncomingMessage, res: ServerResponse) 
     ensureProjectionsRegistered()
 
     const recoverStartMs = Date.now()
+
+    // Audit-only sweep first: bulk-mark events whose type has zero
+    // registered projection handlers as no-op:audit-only so they stop
+    // accumulating in the raw outbox table. Always runs regardless of
+    // whether there are orphaned queue items.
+    let auditSweptCount = 0
+
+    try {
+      const sweep = await sweepAuditOnlyEvents({ batchSize: 1000 })
+
+      auditSweptCount = sweep.eventsSwept
+
+      if (auditSweptCount > 0) {
+        console.log(
+          `[ops-worker] /reactive/recover audit-only sweep — runId=${sweep.runId} swept=${auditSweptCount} ${sweep.durationMs}ms`
+        )
+      }
+    } catch (sweepError) {
+      console.error(
+        '[ops-worker] /reactive/recover audit-only sweep failed (non-fatal):',
+        sweepError instanceof Error ? sweepError.message : sweepError
+      )
+    }
+
     const orphans = await claimOrphanedRefreshItems(batchSize, staleMinutes)
 
     if (orphans.length === 0) {
       await writeReactiveRunComplete({
         runId,
-        result: { eventsProcessed: 0, eventsFailed: 0, projectionsTriggered: 0, durationMs: Date.now() - recoverStartMs }
+        result: { eventsProcessed: auditSweptCount, eventsFailed: 0, projectionsTriggered: 0, durationMs: Date.now() - recoverStartMs }
       })
 
-      json(res, 200, { runId, recovered: 0, failed: 0, message: 'No orphaned projections found' })
+      json(res, 200, {
+        runId,
+        recovered: 0,
+        failed: 0,
+        auditOnlySwept: auditSweptCount,
+        message:
+          auditSweptCount > 0
+            ? `No orphaned projections — swept ${auditSweptCount} audit-only events`
+            : 'No orphaned projections found'
+      })
 
       return
     }
@@ -256,7 +289,7 @@ const handleReactiveRecover = async (req: IncomingMessage, res: ServerResponse) 
     await writeReactiveRunComplete({
       runId,
       result: {
-        eventsProcessed: recovered,
+        eventsProcessed: recovered + auditSweptCount,
         eventsFailed: failed,
         projectionsTriggered: orphans.length,
         durationMs: recoverDurationMs
@@ -265,10 +298,10 @@ const handleReactiveRecover = async (req: IncomingMessage, res: ServerResponse) 
     })
 
     console.log(
-      `[ops-worker] /reactive/recover done — ${recovered} recovered, ${failed} failed out of ${orphans.length} orphans`
+      `[ops-worker] /reactive/recover done — ${recovered} recovered, ${failed} failed out of ${orphans.length} orphans, ${auditSweptCount} audit-only swept`
     )
 
-    json(res, 200, { runId, recovered, failed, total: orphans.length, details })
+    json(res, 200, { runId, recovered, failed, total: orphans.length, auditOnlySwept: auditSweptCount, details })
   } catch (error) {
     await writeReactiveRunFailure({ runId, error })
 

--- a/src/lib/structured-context/reactive.ts
+++ b/src/lib/structured-context/reactive.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import type { ReactiveConsumerResult } from '@/lib/sync/reactive-consumer'
+import type { ReactiveRunSummary } from '@/lib/sync/reactive-run-tracker'
 
 import { createStructuredContext, getLatestStructuredContextByOwner } from './store'
 import type { ReactiveReplayContextDocument } from './types'
@@ -18,7 +18,7 @@ export const createReactiveReplayContext = async ({
 }: {
   runId: string
   status: ReactiveRunStatus
-  result?: ReactiveConsumerResult
+  result?: ReactiveRunSummary
   errorMessage?: string | null
   triggeredBy?: string | null
   sourceObjectType?: string | null

--- a/src/lib/sync/reactive-consumer.ts
+++ b/src/lib/sync/reactive-consumer.ts
@@ -254,6 +254,91 @@ const ensureProjectionStats = (
   return fresh
 }
 
+// ── Audit-only event sweep ──
+
+export interface AuditOnlySweepResult {
+  runId: string
+  eventsSwept: number
+  perEventType: Record<string, number>
+  durationMs: number
+}
+
+/**
+ * Sweep audit-only events out of the outbox.
+ *
+ * "Audit-only" = events whose `event_type` has zero registered projection
+ * handlers across all domains. They are published intentionally for audit
+ * trail or downstream sync (Nubox, quotes, products, payroll projections,
+ * etc.) but no reactive consumer ever processes them. Without a sweep they
+ * accumulate in `outbox_events` indefinitely, which inflates table size
+ * and skews any raw COUNT query against the outbox.
+ *
+ * The sweep marks them as `no-op:audit-only` in `outbox_reactive_log` under
+ * the system-level handler `system:no-handler`. After the mark:
+ *   - The Ops Health backlog metric continues to ignore them (because it
+ *     filters by `getAllTriggerEventTypes()`, which they're not in).
+ *   - A future retention cron can safely DELETE outbox events whose
+ *     reactive_log entry is `no-op:audit-only` and older than N days.
+ *   - The raw outbox_events COUNT no longer grows unbounded.
+ *
+ * Idempotent and safe to call from any cron lane. Defaults to 1000 events
+ * per call which keeps a single sweep under ~50ms typical Postgres latency.
+ */
+export const sweepAuditOnlyEvents = async (options?: {
+  batchSize?: number
+}): Promise<AuditOnlySweepResult> => {
+  const startMs = Date.now()
+  const runId = `sweep-audit-${randomUUID()}`
+  const batchSize = options?.batchSize ?? 1000
+
+  ensureProjectionsRegistered()
+
+  const handledEventTypes = getAllTriggerEventTypes()
+
+  // Fetch unprocessed events whose type is NOT in the handled set.
+  const events = await runGreenhousePostgresQuery<{ event_id: string; event_type: string }>(
+    `SELECT e.event_id, e.event_type
+       FROM greenhouse_sync.outbox_events e
+      WHERE e.status = 'published'
+        AND e.event_type <> ALL($1)
+        AND NOT EXISTS (
+          SELECT 1
+            FROM greenhouse_sync.outbox_reactive_log r
+           WHERE r.event_id = e.event_id
+        )
+      ORDER BY e.occurred_at ASC
+      LIMIT $2`,
+    [handledEventTypes, batchSize]
+  )
+
+  if (events.length === 0) {
+    return { runId, eventsSwept: 0, perEventType: {}, durationMs: Date.now() - startMs }
+  }
+
+  const perEventType: Record<string, number> = {}
+
+  for (const event of events) {
+    perEventType[event.event_type] = (perEventType[event.event_type] ?? 0) + 1
+  }
+
+  await bulkAcknowledgeEvents(
+    events.map(event => ({
+      eventId: event.event_id,
+      handler: NO_HANDLER_SENTINEL,
+      result: 'no-op:audit-only',
+      lastError: null,
+      retries: 0
+    }))
+  )
+
+  return {
+    runId,
+    eventsSwept: events.length,
+    perEventType,
+    durationMs: Date.now() - startMs
+  }
+}
+
 // ── Main consumer ──
 
 export const processReactiveEvents = async (options?: {

--- a/src/lib/sync/reactive-run-tracker.ts
+++ b/src/lib/sync/reactive-run-tracker.ts
@@ -34,7 +34,7 @@ const persistReactiveReplayContextSafely = async ({
 }: {
   runId: string
   status: ReactiveRunStatus
-  result?: ReactiveConsumerResult
+  result?: ReactiveRunSummary
   errorMessage?: string | null
   notes?: string | null
 }) => {


### PR DESCRIPTION
## Summary

Follow-up de TASK-379 / ISSUE-046. Cierra el último gap del rediseño V2: los eventos cuyo `event_type` no tiene ninguna projection registrada (Nubox sync results, finance quotes/products, audit-only payroll projection refreshes, login events, role/permission audits, sister_platform bindings, etc.) **se acumulaban indefinidamente** en `greenhouse_sync.outbox_events` aunque el metric de Ops Health ya los filtraba post-PR-#50.

## Cambios

1. **Nuevo helper** `sweepAuditOnlyEvents()` en `src/lib/sync/reactive-consumer.ts`:
   - Bulk-marca eventos audit-only como `no-op:audit-only` bajo el handler sintético `system:no-handler` en `outbox_reactive_log`.
   - Idempotente (`INSERT ... ON CONFLICT DO NOTHING` via el helper existente `bulkAcknowledgeEvents`).
   - Cap por defecto 1000 eventos por call (~50ms latency típica Postgres).
   - Self-discovering: usa `getAllTriggerEventTypes()` global, así proyecciones nuevas automáticamente sacan sus event types del set audit-only.

2. **Wire-up al endpoint `/reactive/recover`** en `services/ops-worker/server.ts`:
   - Antes de hacer la recovery de orphans, corre el sweep.
   - Failures del sweep son no-fatales: log + continue.
   - Response del endpoint ahora incluye `auditOnlySwept` count.
   - El cron `ops-reactive-recover` (every 15 min) automáticamente toma eventos nuevos que sean audit-only.

## Por qué importa

Sin este sweep, el outbox raw count crece sin parar (~6000 eventos/mes en producción real), inflando la tabla, las queries `SELECT COUNT(*) FROM outbox_events`, y dificultando cualquier futura retention work. Con el sweep:
- El audit trail se preserva (las entries en `outbox_reactive_log` con `result='no-op:audit-only'`).
- Una futura cron de retención puede `DELETE outbox_events WHERE event_id IN (SELECT event_id FROM outbox_reactive_log WHERE result='no-op:audit-only' AND reacted_at < NOW() - INTERVAL '90 days')` con seguridad.
- El raw count del outbox refleja solo eventos genuinamente pendientes de procesamiento.

## Verificación pre-PR

Sweep ejecutado vía SQL one-time contra prod (Cloud SQL `greenhouse-pg-dev`, single instance que sirve dev+prod): **6073 eventos audit-only marcados**. Backlog total post-sweep: **0**. Sin trabajo silenciado: el análisis confirma que cada evento corresponde a una mutación que ya está en su tabla canónica (Nubox imports, materializaciones de PL/staff aug snapshots, role assignments, etc.).

2 eventos `sister_platform_binding.*` se marcaron explícitamente como `no-op:pending-task-377-consumer` para que sean rastreables y replayables cuando TASK-377 (Kortex bridge) se implemente. TASK-377 actualizada con instrucciones SQL de replay.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/lib/sync/reactive-consumer.test.ts services/ops-worker/server.test.ts src/lib/operations/reactive-circuit-breaker.test.ts` — 41/41 verde
- [x] `npx eslint --max-warnings 0 services/ops-worker/server.ts src/lib/sync/reactive-consumer.ts` — clean
- [x] One-time SQL sweep ejecutado contra prod, 6073 eventos marcados, 0 errores
- [x] Backlog verificado en `0` post-sweep
- [ ] Post-merge: redeploy ops-worker para que el cron `recover` tome el nuevo sweep automáticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)