### PR TITLE
fix(tests): email delivery test fixes for TASK-382 behavior

### DIFF
--- a/src/lib/email/delivery.test.ts
+++ b/src/lib/email/delivery.test.ts
@@ -98,7 +98,7 @@ describe('email delivery layer', () => {
 
   it('retries failed deliveries using the persisted replay payload', async () => {
     mockRunGreenhousePostgresQuery.mockImplementation((sql: string) => {
-      if (sql.includes("WHERE status = 'failed'")) {
+      if (sql.includes("status = 'failed' AND attempt_number")) {
         return Promise.resolve([
           {
             delivery_id: 'delivery-claim-1',
@@ -214,7 +214,7 @@ describe('email delivery layer', () => {
     )
   })
 
-  it('returns skipped aggregate when all recipients are skipped (e.g. RESEND_API_KEY missing)', async () => {
+  it('returns failed aggregate when RESEND_API_KEY is not configured (config error is retryable)', async () => {
     mockIsResendConfigured.mockReturnValue(false)
 
     const result = await sendEmail({
@@ -224,8 +224,8 @@ describe('email delivery layer', () => {
       context: { title: 'Test', body: 'Test body' }
     })
 
-    expect(result.status).toBe('skipped')
+    expect(result.status).toBe('failed')
     expect(result.recipientResults).toBeDefined()
-    expect(result.recipientResults?.[0]?.status).toBe('skipped')
+    expect(result.recipientResults?.[0]?.status).toBe('failed')
   })
 })


### PR DESCRIPTION
## Summary

- Fix 2 tests en `src/lib/email/delivery.test.ts` que fallaron después del merge de TASK-382
- El test de retry usaba substring match `WHERE status = 'failed'` que dejó de funcionar cuando la query cambió a `WHERE (\n  (status = 'failed' AND attempt_number < 3)\n  OR (status = 'rate_limited' ...)`
- El test de RESEND_API_KEY missing esperaba `'skipped'` pero TASK-382 cambió el comportamiento correcto a `'failed'` (retryable)

## No hay cambios de comportamiento — solo ajuste de tests al comportamiento ya implementado

🤖 Generated with [Claude Code](https://claude.com/claude-code)