### PR TITLE
fix: add Service SLA route to admin sidebar

### DIFF
--- a/src/components/layout/vertical/VerticalMenu.tsx
+++ b/src/components/layout/vertical/VerticalMenu.tsx
@@ -417,12 +417,14 @@ const VerticalMenu = ({ scrollMenu }: Props) => {
               { label: nl(GH_INTERNAL_NAV.adminTalentReview), href: '/admin/talent-review', icon: 'tabler-rosette-discount-check' },
               { label: nl(GH_INTERNAL_NAV.adminTalentOps), href: '/admin/talent-ops', icon: 'tabler-heart-rate-monitor' },
               { label: nl(GH_INTERNAL_NAV.adminBusinessLines), href: '/admin/business-lines' },
+              { label: nl(GH_INTERNAL_NAV.adminServiceSlas), href: '/admin/service-slas', icon: 'tabler-shield-check' },
               { label: nl(GH_INTERNAL_NAV.adminPaymentInstruments), href: '/admin/payment-instruments' }
             ].filter(item => {
               if (item.href === '/admin/team') return canSeeView('administracion.equipo', true)
               if (item.href === '/admin/talent-review') return canSeeView('administracion.equipo', true)
               if (item.href === '/admin/talent-ops') return canSeeView('administracion.equipo', true)
               if (item.href === '/admin/business-lines') return canSeeView('administracion.admin_center', true)
+              if (item.href === '/admin/service-slas') return canSeeView('administracion.admin_center', true)
               if (item.href === '/admin/payment-instruments') return canSeeView('administracion.instrumentos_pago', true)
 
               return true

--- a/src/config/greenhouse-nomenclature.ts
+++ b/src/config/greenhouse-nomenclature.ts
@@ -30,6 +30,7 @@ export const GH_INTERNAL_NAV = {
   adminNotifications: { label: 'Notificaciones', subtitle: 'Sistema de notificaciones in-app y email' },
   adminOpsHealth: { label: 'Ops Health', subtitle: 'Outbox, proyecciones y freshness del serving' },
   adminBusinessLines: { label: 'Business Lines', subtitle: 'Metadata canonica de las lineas de negocio' },
+  adminServiceSlas: { label: 'SLA de servicios', subtitle: 'Gobernanza contractual por servicio y cumplimiento' },
   adminIntegrationGovernance: { label: 'Integration Governance', subtitle: 'Registro, taxonomia, readiness y ownership de integraciones nativas' },
   adminAccounts: { label: 'Cuentas', subtitle: 'Organizaciones, spaces y gobierno de identidad' },
   adminPaymentInstruments: { label: 'Instrumentos de pago', subtitle: 'Cuentas bancarias, tarjetas, fintech y plataformas' },


### PR DESCRIPTION
## Summary
- add a dedicated Admin Center sidebar entry for Service SLA governance
- reuse Greenhouse internal navigation nomenclature for the new menu item
- keep access gated by the existing admin center authorization contract

## Validation
- pnpm exec eslint src/config/greenhouse-nomenclature.ts src/components/layout/vertical/VerticalMenu.tsx
- pnpm exec next build --webpack
