### PR TITLE
fix(ci): raise vitest timeout to 15s for coverage mode (ISSUE-052)

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -64,7 +64,7 @@ Tasks, docs de arquitectura, o commits relacionados.
 
 ## Siguiente ID disponible
 
-`ISSUE-052`
+`ISSUE-053`
 
 ## Open
 
@@ -86,6 +86,7 @@ Tasks, docs de arquitectura, o commits relacionados.
 | `ISSUE-023` | [Tablas de email sin migracion formal](resolved/ISSUE-023-email-tables-no-formal-migration.md)                                   | production + staging | 2026-04-06 | 2026-04-13 | Migraciones formales creadas en TASK-382: `20260413162215719_email-notifications-schema-foundation.sql` + `20260413162238855_email-delivery-enterprise-v2.sql` |
 | `ISSUE-020` | [3 endpoints duplicados de retry batch sin error handling](resolved/ISSUE-020-duplicate-email-retry-endpoints.md)                | staging + production | 2026-04-06 | 2026-04-13 | STALE — duplicados ya habian sido removidos. Solo existe `/api/admin/ops/email-delivery-retry` con try-catch. Verificado en auditoria TASK-382. |
 | `ISSUE-046` | [Reactive pipeline silent-skip backlog (~11k eventos sin procesar)](resolved/ISSUE-046-reactive-pipeline-silent-skip-backlog.md) | staging + production (single-instance) | 2026-04-13 | 2026-04-13 | Consumer V1 silent-skip path + fan-out explosion. Resuelto por TASK-379 (PR #53) + audit-only sweep follow-up (PR #54). Backlog drenado de 11,495 → 0. |
+| `ISSUE-052` | [CI `test:coverage` flake: HrLeaveView backfill dialog times out](resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md) | CI (GitHub Actions) | 2026-04-17 | 2026-04-17 | Vitest `testTimeout` default de 5s quedaba corto bajo instrumentación v8 de coverage en GitHub runners. Fix: bump global a 15s en `vitest.config.ts`. Desbloquea 5 commits de `develop` con CI rojo por flake no-reproducible localmente. |
 | `ISSUE-031` | [Vercel Preview falla en build por drift de `NEXTAUTH_SECRET`](resolved/ISSUE-031-vercel-preview-build-fails-missing-nextauth-secret.md)                        | preview                        | 2026-04-08 | 2026-04-08 | `authOptions` se resolvía en import-time y Preview no tenía `NEXTAUTH_SECRET`, por lo que el build caía en page-data collection |
 | `ISSUE-032` | [Secret Manager payload contamination breaks runtime secrets](resolved/ISSUE-032-secret-manager-payload-contamination-breaks-runtime-secrets.md)                 | staging + production           | 2026-04-08 | 2026-04-09 | Payloads de Secret Manager publicados con comillas/`\\n` literal llegaban sucios al runtime y rompían auth/integraciones |
 | `ISSUE-027` | [My Profile vacío tras migración a Person 360: resolución "me" retorna 404](resolved/ISSUE-027-my-profile-360-me-resolution-404.md)                               | staging                        | 2026-04-07 | 2026-04-07 | `resolvePersonIdentifier` no buscaba por `identity_profile_id` — WHERE clause solo tenía `member_id OR user_id`          |

--- a/docs/issues/resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md
+++ b/docs/issues/resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md
@@ -1,0 +1,91 @@
+# ISSUE-052 — CI `test:coverage` flake: HrLeaveView backfill dialog times out
+
+## Ambiente
+
+CI (GitHub Actions) — el workflow `CI > Lint, test and build`, step `Coverage`.
+
+## Detectado
+
+2026-04-17 — PR #63 (TASK-446) falla en CI. Auditoría posterior muestra que `develop` tiene los últimos 5 commits con la misma falla (runs `24550667620`, `24550905750`, `24550969181`, `24555918188`, `24559856272`), incluyendo cierres docs-only que no tocan código.
+
+## Síntoma
+
+```
+FAIL  src/views/greenhouse/hr-core/HrLeaveView.test.tsx > HrLeaveView
+  > opens the backfill dialog from a balance row and posts the selected member and leave type
+
+Error: Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it
+globally with "testTimeout".
+
+Uncaught Exception
+ReferenceError: window is not defined
+  at performWorkOnRootViaSchedulerTask (react-dom-client.development.js:18936)
+```
+
+Localmente el test pasa con `pnpm test` (sin coverage). Solo falla con `pnpm test:coverage` o en el runner de CI que usa ese comando.
+
+## Causa raíz
+
+- `vitest.config.ts` no declaraba `testTimeout`, usando el default de Vitest de **5000ms**.
+- El test de HR leave backfill ejecuta una cadena realista de 8 interacciones: render → click tab → click "Ver detalle" → `findByRole('dialog')` → click "Registrar días ya tomados" → llenar 4 campos → click "Registrar" → `waitFor` sobre payload POST.
+- La instrumentación `v8` de `pnpm test:coverage` agrega overhead significativo (5–10x) a cada ciclo de reconciliación de React. En el GitHub runner con recursos compartidos, la cadena excede 5000ms.
+- Al timeout, `afterEach(() => cleanup())` desmonta el árbol mientras React aún tiene trabajo pendiente → `ReferenceError: window is not defined` durante el flush final del scheduler.
+- El error `window is not defined` es síntoma, no causa: es el jsdom environment desmontándose antes de que React termine su render work.
+
+## Impacto
+
+- **CI de `develop` en rojo 5 commits consecutivos** (tanto commits de código como docs-only). Ningún PR posterior podía pasar gate sin override.
+- **Throughput de merges bloqueado** para todo agente/humano que dependa de CI verde.
+- **Señal de calidad degradada:** el equipo pierde visibilidad de fallas reales porque "CI rojo" se normaliza como ruido.
+
+## Solución
+
+Ampliar `testTimeout` y `hookTimeout` globales en `vitest.config.ts` de 5s → **15s**. Razones:
+
+- El trabajo del test no es buggy, simplemente el budget de 5s era demasiado apretado para coverage mode en runners compartidos.
+- 15s sigue siendo lo suficientemente corto para detectar tests genuinamente colgados (infinite loops, hung fetch mocks).
+- Fix global vs. per-test: beneficia a todo el suite sin tocar código de HR (que es de otro dominio, TASK-415/ISSUE-049).
+- Agrega `hookTimeout` también para cubrir `beforeEach`/`afterEach` con imports async o setup pesado.
+
+```ts
+// vitest.config.ts
+test: {
+  // ...
+  testTimeout: 15000,
+  hookTimeout: 15000,
+  // ...
+}
+```
+
+No se modifica ningún test. Enfoque no-invasivo y anclado al config global.
+
+## Verificación
+
+- Local: `pnpm test:coverage` debe terminar sin timeouts.
+- CI: siguiente run del workflow `Lint, test and build` sobre PR #64 (este fix) debe pasar `Coverage` step.
+- Gate de regresión: commits subsecuentes en `develop` deben retomar CI verde consistente.
+
+## Estado
+
+resolved
+
+## Relacionado
+
+- **Fix PR:** #64 — `fix/ci-coverage-test-timeout` → `develop`
+- **Gating PR:** #63 (TASK-446 Nexa Insights root cause narrative surfacing) — bloqueada por este flake; se rebaseará sobre `develop` verde y se mergeará después de este fix.
+- **Runs afectados** (antes del fix):
+  - `24550667620` — feat: rescope agency campaigns api
+  - `24550905750` — feat: close agency campaigns api rescope
+  - `24550969181` — docs(tasks): align client portal tasks with entitlements
+  - `24555918188` — fix: harden nexa project label resolution (TASK-440)
+  - `24559856272` — docs: close TASK-343 quotation program umbrella
+  - `24561762409` — TASK-446 PR #63 initial run
+- **Tests afectados observados:**
+  - `src/views/greenhouse/hr-core/HrLeaveView.test.tsx:352` — "opens the backfill dialog"
+  - `src/views/greenhouse/hr-core/HrLeaveView.test.tsx:612` — "shows enriched identity avatars" (falla intermitente en `24559856272`, probable mismo patrón)
+
+## Follow-ups opcionales (no parte de este fix)
+
+- HR team puede revisar `HrLeaveView.test.tsx` para migrar de `fireEvent` a `userEvent` (más realista y típicamente más estable bajo instrumentación).
+- Considerar instrumentación coverage más liviana (`istanbul` en vez de `v8`) si la overhead vuelve a ser problemática — trade-off con precisión de métricas.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,14 @@ export default defineConfig({
       'services/**/*.spec.ts'
     ],
     setupFiles: ['src/test/setup.ts'],
+
+    // Raised from Vitest default (5s) to give React component suites headroom
+    // under v8 coverage instrumentation on GitHub runners. Multi-step dialog/form
+    // tests in `pnpm test:coverage` were exceeding 5s in CI while passing locally
+    // (ISSUE-052). 15s still catches genuinely hung tests.
+    testTimeout: 15000,
+    hookTimeout: 15000,
+
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],


### PR DESCRIPTION
## Summary

- Sube `testTimeout` y `hookTimeout` de Vitest de 5s → 15s en [vitest.config.ts](vitest.config.ts) para dar aire a tests React-heavy bajo instrumentación `v8` de coverage en runners de GitHub Actions.
- Cierra **ISSUE-052** ([docs](docs/issues/resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md)): el test `HrLeaveView > opens the backfill dialog from a balance row` timea en CI pero pasa local. Causa raíz documentada completa.
- **Desbloquea develop:** los últimos 5 commits (incluyendo docs-only closures) tienen CI rojo por este flake, bloqueando el pipeline para todo agente/humano.

## Root cause (resumen)

- Vitest default `testTimeout` = 5000ms.
- Tests multi-paso de diálogos MUI (8 interacciones secuenciales con reconciliación React entre cada una) exceden 5s con instrumentación `v8` de coverage en runners compartidos.
- Al timeout, `afterEach(cleanup)` desmonta jsdom mientras React sigue con trabajo pendiente → `ReferenceError: window is not defined` como síntoma colateral.
- Localmente `pnpm test` pasa; solo `pnpm test:coverage` en CI reproduce el flake.

## Fix

```ts
// vitest.config.ts
test: {
  // ...
  testTimeout: 15000,
  hookTimeout: 15000,
  // ...
}
```

- 15s es suficiente headroom para tests legítimos bajo coverage.
- Sigue catching tests genuinamente colgados (infinite loops, hung mocks).
- Cambio global = beneficio para todo el suite, incluyendo tests futuros.
- No modifica código de tests (scope limpio).

## Verificación local

\`\`\`
pnpm test:coverage
# → 1269 pass | 2 skipped | 0 failed (23.04s)
\`\`\`

## Test plan

- [ ] CI `Lint, test and build > Coverage` pasa en este PR
- [ ] Una vez mergeada a develop, próximo commit en develop debe tener CI verde (regresión prevenida)

## Impacto

- **Desbloquea:** PR #63 (TASK-446 Nexa Insights root cause narrative surfacing) y cualquier otra PR pendiente que necesite CI verde.
- **Zero-risk:** no toca código de producción, solo config de test runner y un doc de incidente.

## Relacionado

- ISSUE-052: [docs/issues/resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md](docs/issues/resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md)
- Runs de CI rojos afectados: 24550667620, 24550905750, 24550969181, 24555918188, 24559856272, 24561762409

🤖 Generated with [Claude Code](https://claude.com/claude-code)