### PR TITLE
docs(operations): multi-agent integration patterns from Claude+Codex parallel session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,10 @@ Este repositorio es la base operativa de Greenhouse sobre Vuexy + Next.js. Aqui 
   - cambio supuestos del proyecto
 - Si dos agentes pueden tocar la misma zona, prevalece el ultimo handoff documentado, no la memoria conversacional.
 - Si otro agente ya esta trabajando en el workspace actual y hace falta otra rama, **no cambiar la rama de ese checkout**; abrir un `git worktree` aislado. Fuente canonica: `docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md`.
+- Cuando tomes un worktree pre-existente, NO correr `pnpm install` a ciegas. Verificar primero lockfile md5 vs `main`; reutilizar `node_modules`, y symlinkear `.env.local` / `.vercel/` si no existen. Detalle: [Higiene de worktree preexistente](docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md#higiene-de-worktree-preexistente).
+- Cuando dos PRs vayan a `develop` en paralelo, usar `git rebase --onto origin/develop <other-agent-commit>` para separar scope y `git push --force-with-lease` (nunca `--force` solo). Detalle: [Patrones de integración multi-agente](docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md#patrones-de-integración-multi-agente).
+- Si tu PR falla CI por un test que no tocaste, **no hacer admin override**. Triage: correr `pnpm test:coverage` local y revisar los últimos runs de `develop`. Si el flake es heredado, abrir `ISSUE-###` + PR separada de fix → merge → rebase tu PR original. Detalle: [CI como gate compartido](docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md#ci-como-gate-compartido).
+- Merge a `develop` es siempre **squash merge + delete branch**. `develop` no tiene branch protection, entonces `gh pr merge --auto` no funciona — usar background watcher (`until CI completed; gh pr merge --squash --delete-branch`). Detalle: [Merge policy canónica](docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md#merge-policy-canónica).
 
 ### 4. Regla de cambios minimos
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ Regla: módulos de dominio extienden estos objetos, no crean identidades paralel
   - `docs/operations/GREENHOUSE_CLOUD_GOVERNANCE_OPERATING_MODEL_V1.md`
   - `docs/architecture/GREENHOUSE_CLOUD_SECURITY_POSTURE_V1.md`
   - `docs/architecture/GREENHOUSE_CLOUD_INFRASTRUCTURE_V1.md`
+- Fuente canónica para trabajo multi-agente (Claude + Codex en paralelo):
+  - `docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md` — incluye higiene de worktrees, `rebase --onto`, `force-push-with-lease`, CI como gate compartido, squash merge policy, background watcher pattern para auto-merge sin branch protection
 - Convenciones de skills locales:
   - Claude: `.claude/skills/<skill-name>/skill.md` (minuscula)
   - Codex: `.codex/skills/<skill-name>/SKILL.md` (mayuscula)

--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,22 @@
 # Handoff.md
 
+## Sesion 2026-04-17 — Multi-agent integration patterns documentados
+
+- **Estado:** `complete`, `PR abierta contra develop`
+- **Rama:** `docs/multi-agent-integration-patterns`
+- **Motivación:** tras cerrar TASK-446 en paralelo con TASK-345 de Codex, las lecciones operativas (worktree hygiene, rebase --onto, CI flake heredado, squash merge sin branch protection) quedaban sin canónico. Las formalizamos antes de que la próxima sesión descubra esto a fuego.
+- **Implementado:**
+  - `docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md` con 4 secciones nuevas:
+    - Higiene de worktree preexistente
+    - Patrones de integración multi-agente
+    - CI como gate compartido
+    - Merge policy canónica
+  - `AGENTS.md` Regla 3 ("Coordinacion entre agentes") agrega 4 pointers breves a las nuevas secciones.
+  - `CLAUDE.md` Key Docs agrega entry canónica para trabajo multi-agente.
+  - `changelog.md` registra la política nueva.
+- **Caso base referenciado:** ISSUE-052 (flake `HrLeaveView.test.tsx` bajo `pnpm test:coverage`), resuelto en PR #65 con bump `testTimeout` 5s → 15s; desbloqueó PR #63 y toda la queue de develop.
+- **No cambios de runtime:** pura documentación operativa. Zero riesgo de regresión.
+
 ## Sesion 2026-04-17 — TASK-446 Nexa Insights Root Cause Narrative Surfacing (Insights Quick Win)
 
 - **Estado:** `complete`, `documentado`, `branch task/TASK-446-nexa-insights-root-cause-narrative`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ## 2026-04-17
 
+### 2026-04-17 — Patrones multi-agente documentados en modelo operativo canónico
+
+- `docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md` incorpora 4 secciones nuevas aprendidas en la sesión paralela Claude (TASK-446) + Codex (TASK-345):
+  - **Higiene de worktree preexistente** — checklist `md5sum pnpm-lock.yaml`, `diff package.json`, symlinks `.env.local` / `.vercel/`, cleanup de `.next-local/build-*`. Evita `pnpm install` innecesario cuando el worktree heredado ya está consistente.
+  - **Patrones de integración multi-agente** — `git rebase --onto origin/develop <other-agent-commit>` para separar scope, `git push --force-with-lease` (nunca `--force` solo), hotspots de conflict recurrentes (`Handoff.md`, `changelog.md`, `docs/tasks/README.md`, `TASK_ID_REGISTRY.md`, `docs/issues/README.md`), rebase cascading cuando develop avanza durante el CI.
+  - **CI como gate compartido** — protocolo de triage antes de asumir culpa (local vs runs previos en develop), regla "no admin override por flake heredado", ISSUE-### + PR separada de fix → merge → rebase PR original. Ejemplo canónico: ISSUE-052.
+  - **Merge policy canónica** — squash merge obligatorio, `gh pr merge --auto` nativo no funciona por ausencia de branch protection en develop, background watcher `until CI completed; gh pr merge --squash --delete-branch`, caveat de checkout local fallando cuando otro worktree tiene develop.
+- `AGENTS.md` Regla 3 (coordinación entre agentes) y `CLAUDE.md` Key Docs agregan pointers directos a las nuevas secciones.
+
 ### 2026-04-17 — TASK-446: Nexa Insights expone `rootCauseNarrative` en UI, Weekly Digest y API
 
 - La narrativa causal (distinta al resumen del impacto) que Gemini ya generaba deja de descartarse en el serving layer.

--- a/docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md
+++ b/docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md
@@ -1,5 +1,16 @@
 # MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md
 
+## Delta 2026-04-17 — patrones aprendidos en sesión paralela Claude + Codex
+
+Sesión simultánea de TASK-446 (Claude, Insights root cause narrative) y TASK-345 (Codex, quotation canonical bridge) materializó patrones operativos que el modelo original no cubría. Se agregan las secciones:
+
+- [Higiene de worktree preexistente](#higiene-de-worktree-preexistente) — cómo validar que un worktree heredado está listo sin hacer `pnpm install` ciego
+- [Patrones de integración multi-agente](#patrones-de-integración-multi-agente) — `rebase --onto`, `force-push-with-lease`, hotspots de conflicto
+- [CI como gate compartido](#ci-como-gate-compartido) — protocolo cuando `develop` queda en rojo por flake ajeno
+- [Merge policy canónica](#merge-policy-canónica) — squash merge + background watcher para auto-merge cuando no hay branch protection
+
+Contexto que originó el delta: ambos agentes abrieron PR contra `develop` simultáneamente, Codex mergeó TASK-345 mientras el CI de Claude corría, y un flake pre-existente en `HrLeaveView.test.tsx` bloqueaba todo el pipeline. Los patrones canónicos quedan para que la próxima sesión no descubra estas lecciones a fuego.
+
 ## Objetivo
 
 Permitir que múltiples agentes trabajen en paralelo sobre el mismo repositorio sin pisarse el checkout, sin cambiarle la rama al otro agente y sin convertir el workspace compartido en una fuente de conflictos operativos.
@@ -286,6 +297,223 @@ Formato sugerido:
 - `worktree Codex: /Users/.../greenhouse-eo-codex-task-380`
 - `rama: task/TASK-380-structured-context-layer-foundation`
 
+## Higiene de worktree preexistente
+
+Cuando un agente toma un worktree que otro agente ya usó (ej: sesión anterior cerrada sin remove), **NO hacer `pnpm install` ni `git clean -fdx` a ciegas**. Validar primero:
+
+### Checklist rápido (< 30 segundos)
+
+```bash
+# 1. Lockfile consistente con el main repo
+md5sum /path/to/main/pnpm-lock.yaml /path/to/worktree/pnpm-lock.yaml
+# → mismos hashes = node_modules sirve, no reinstalar
+
+# 2. package.json idéntico
+diff /path/to/main/package.json /path/to/worktree/package.json
+
+# 3. node_modules poblado
+ls /path/to/worktree/node_modules/.pnpm | head
+du -sh /path/to/worktree/node_modules  # debería ser ~2G
+
+# 4. .env.local existe (idealmente symlink al main)
+ls -la /path/to/worktree/.env.local
+
+# 5. .vercel/ presente si vas a usar vercel CLI
+ls /path/to/worktree/.vercel
+```
+
+### Pattern: symlink de config compartida
+
+Para evitar drift entre worktrees y el workspace principal, **symlinkear** los archivos de config estable:
+
+```bash
+# .env.local (secretos, idéntico entre worktrees)
+ln -s /path/to/main/.env.local /path/to/worktree/.env.local
+
+# .vercel/ (project link + env files descargados)
+ln -s /path/to/main/.vercel /path/to/worktree/.vercel
+```
+
+Archivos que NO symlinkear (son per-worktree):
+
+- `.next/`, `.next-local/` (build artifacts)
+- `.vscode/mcp.json` (config MCP del agente específico)
+- cualquier cosa en `artifacts/` o caches locales
+
+### Cleanup de caches stale
+
+Si el worktree tiene builds viejos, limpiar antes de `pnpm dev`/`pnpm build`:
+
+```bash
+rm -rf /path/to/worktree/.next /path/to/worktree/.next-local/build-*
+```
+
+El directorio `.next-local/` se puede dejar vacío — `scripts/next-dist-dir.mjs` lo repuebla.
+
+## Patrones de integración multi-agente
+
+Cuando dos agentes pushean ramas en paralelo con targets a `develop`, la segunda PR en mergear hereda los commits de la primera. Patrones canónicos:
+
+### 1. `rebase --onto` para separar scope
+
+Si tu rama se basó en un commit de otro agente (ej: `fe3b274c` de Codex) que NO quieres arrastrar en tu PR:
+
+```bash
+git fetch origin develop
+git rebase --onto origin/develop <other-agent-commit> <your-branch>
+# ejemplo concreto: git rebase --onto origin/develop fe3b274c
+```
+
+Esto reescribe tu historial para que tus commits queden directamente sobre `origin/develop`, saltándose el del otro agente. Esencial cuando el otro agente hará merge por su propia PR y no querés duplicar su trabajo ni pisarle la atribución.
+
+### 2. `git push --force-with-lease`
+
+Nunca `git push --force` en ramas compartidas (incluso la tuya propia). Usar siempre `--force-with-lease`:
+
+```bash
+git push --force-with-lease origin <your-branch>
+```
+
+`--force-with-lease` aborta si alguien más pusheó a la rama mientras rebaseabas. Protección contra race conditions silenciosas.
+
+### 3. Conflict hotspots — archivos que cada sesión toca
+
+Estos archivos son zona de conflict casi garantizada entre PRs paralelas:
+
+| Archivo | Por qué |
+|---|---|
+| `Handoff.md` | Cada sesión agrega entry al top |
+| `changelog.md` | Cada PR documenta cambio |
+| `docs/tasks/README.md` | Cada task update toca la tabla |
+| `docs/tasks/TASK_ID_REGISTRY.md` | Cada task nueva agrega fila |
+| `docs/issues/README.md` | Si abres ISSUE, toca la tabla |
+
+Cuando haya conflict en estos archivos durante rebase:
+
+- **No perder contenido ajeno.** Si el HEAD side tiene una entry de otro agente, conservarla.
+- **Orden canónico:** tu entry más reciente arriba, la del otro agente debajo (reverse chronological por merge time, no por session time).
+- **Duplicados:** si tu branch arrastra una entry que ya está en `develop` via otra PR, dropearla — es redundante y puede re-introducir contenido que el otro agente removió intencionalmente.
+
+### 4. Rebase cascading — un solo rebase puede no ser suficiente
+
+Si mientras tu CI corre otro agente mergea una PR a `develop`, tu rama vuelve a quedar desincronizada. Protocolo:
+
+```bash
+# Antes de hacer gh pr merge, verificar
+git fetch origin develop
+git rev-list --count origin/develop..HEAD  # tus commits ahead
+git rev-list --count HEAD..origin/develop  # commits que te faltan
+
+# Si HEAD..origin/develop > 0, rebasear otra vez
+git rebase origin/develop
+# resolver conflicts
+git push --force-with-lease
+```
+
+GitHub marca la PR como `DIRTY` / `CONFLICTING` cuando esto pasa. El background watcher debe reintentar rebase, no asumir que la primera verde del CI garantiza merge.
+
+## CI como gate compartido
+
+El workflow `Lint, test and build` en `develop` actúa como rollup gate: **si está rojo, todas las PRs subsecuentes heredan el fail**. Protocolo canónico:
+
+### Triage antes de asumir culpa
+
+Cuando tu PR falla CI:
+
+```bash
+# 1. ¿Mi cambio rompió?
+pnpm lint && pnpm tsc --noEmit && pnpm test:coverage
+
+# 2. Si local pasa, revisar qué step de CI falla
+gh run view <run-id> --log-failed | head -100
+
+# 3. Si el fail es en un archivo que NO tocaste, revisar runs previos en develop
+gh run list --branch develop --workflow CI --limit 5 --json conclusion
+# → si las últimas 3+ runs en develop también fallan → flake heredado, no tuyo
+```
+
+### Si el flake es heredado
+
+NO mergear con admin override — desbloquea tu PR pero perpetúa el problema.
+
+**Protocolo correcto:**
+
+1. Abrir `ISSUE-###` en `docs/issues/resolved/` (o `open/` si no puedes fixear)
+2. Crear rama separada `fix/ci-<brief-slug>` desde `origin/develop`
+3. Implementar el fix canónico (no solo workaround)
+4. PR independiente → review/CI/merge a `develop`
+5. **Rebasear tu PR original** sobre el develop ya verde
+6. Re-disparar CI de tu PR → pasa limpio
+7. Merge normal
+
+Este protocolo cuesta más tiempo pero:
+
+- Desbloquea a todos los agentes subsecuentes
+- Crea audit trail del incidente
+- Mantiene la señal "CI rojo = problema real" en vez de normalizar ruido
+
+### Ejemplo canónico: ISSUE-052
+
+Sesión 2026-04-17: Claude descubrió que `HrLeaveView.test.tsx:352` timeouteaba en `pnpm test:coverage` (no en `pnpm test`). Últimos 5 commits en develop tenían CI rojo por lo mismo. Fix: bump `testTimeout` de 5s → 15s en `vitest.config.ts` ([PR #65](https://github.com/efeoncepro/greenhouse-eo/pull/65)). Desbloqueó PR #63 y toda la queue futura.
+
+## Merge policy canónica
+
+`develop` **no tiene branch protection rules configuradas**. Consecuencias:
+
+- `gh pr merge --auto` nativo no funciona (`enablePullRequestAutoMerge` rechaza sin branch protection)
+- Merge requiere ejecución manual cuando CI está verde
+
+### Pattern canónico: background watcher + auto-merge
+
+```bash
+until [ "$(gh run view <RUN_ID> --json status --jq '.status')" = "completed" ]; do
+  sleep 30
+done
+CONCLUSION=$(gh run view <RUN_ID> --json conclusion --jq '.conclusion')
+if [ "$CONCLUSION" = "success" ]; then
+  gh pr merge <PR> --squash --delete-branch
+else
+  echo "CI failed, manual intervention required"
+fi
+```
+
+Correr con `run_in_background: true` para no bloquear el agente. Recibís notificación cuando el merge ocurre.
+
+### Squash merge siempre
+
+Toda PR a `develop` usa **squash merge**. Razones:
+
+- Un commit por feature en `develop` — historial legible
+- Rollback trivial (`git revert <squash-commit>`)
+- Attribution correcta (el squash commit queda atribuido al PR author)
+- WIP commits del feature branch no ensucian develop
+
+### Delete branch al mergear
+
+`gh pr merge --squash --delete-branch` borra la rama remota. La rama local del agente queda huérfana — limpieza opcional:
+
+```bash
+git fetch --prune origin
+git branch -D <feature-branch>  # si no está en uso por worktree
+```
+
+### Caveat: el checkout del lado local
+
+`gh pr merge` intenta hacer checkout de la base branch después del merge. Si `develop` está ocupado en otro worktree, verás:
+
+```
+failed to run git: fatal: 'develop' is already used by worktree at '/path/to/other-worktree'
+=== MERGED TO DEVELOP ===
+```
+
+**El merge en GitHub es exitoso** — solo el checkout local post-merge falla, que no importa. Verificar con:
+
+```bash
+gh pr view <PR> --json state,mergedAt,mergeCommit
+```
+
+Si `state: MERGED`, el trabajo quedó. El otro worktree se sincroniza con `git pull --ff-only origin develop` desde su propia carpeta.
+
 ## Resumen operativo
 
 La regla corta es esta:
@@ -296,3 +524,5 @@ La regla corta es esta:
 - trabaja en tu propia rama
 - sincroniza desde tu propia carpeta
 - cierra con commit, push y handoff
+- si CI falla por flake heredado, abrir ISSUE + PR separada antes de mergear tu feature
+- merge a `develop` vía squash + delete branch; nunca --force-push sin --with-lease


### PR DESCRIPTION
## Summary

Documenta patrones operativos aprendidos en la sesión paralela del 2026-04-17 (Claude + Codex). Zero runtime changes — pura documentación operativa canónica.

### Contexto

Durante la sesión, Claude mergeó [PR #63](https://github.com/efeoncepro/greenhouse-eo/pull/63) (TASK-446 Nexa Insights root cause) mientras Codex mergeaba [PR #64](https://github.com/efeoncepro/greenhouse-eo/pull/64) (TASK-345 Quotation canonical bridge). Además un flake en \`HrLeaveView.test.tsx\` ([ISSUE-052](docs/issues/resolved/ISSUE-052-ci-coverage-flake-hr-leave-timeout.md)) tenía develop en rojo hace 5 commits. El camino de resolución produjo lecciones que el modelo operativo canónico no cubría.

## Cambios

### `docs/operations/MULTI_AGENT_WORKTREE_OPERATING_MODEL_V1.md`
4 secciones nuevas + delta al top apuntando a ellas:

1. **Higiene de worktree preexistente** — checklist \`md5sum pnpm-lock.yaml\`, \`diff package.json\`, symlinks \`.env.local\` / \`.vercel/\`, cleanup de \`.next-local/build-*\`. Evita \`pnpm install\` innecesario cuando un worktree heredado ya está consistente.

2. **Patrones de integración multi-agente** — \`git rebase --onto origin/develop <other-agent-commit>\` para separar scope, \`git push --force-with-lease\` (nunca \`--force\` solo), hotspots de conflict (Handoff.md, changelog.md, docs/tasks/README.md, TASK_ID_REGISTRY.md), rebase cascading cuando develop avanza durante el CI.

3. **CI como gate compartido** — protocolo de triage antes de asumir culpa, regla \"no admin override por flake heredado\", ISSUE-### + PR separada de fix → merge → rebase PR original.

4. **Merge policy canónica** — squash merge obligatorio, \`gh pr merge --auto\` nativo no funciona sin branch protection, background watcher pattern, caveat de checkout local fallando cuando otro worktree tiene develop.

### \`AGENTS.md\`
Regla 3 (\"Coordinacion entre agentes\") agrega 4 sub-bullets con pointers directos a las nuevas secciones.

### \`CLAUDE.md\`
Key Docs agrega entry canónica para trabajo multi-agente.

### \`changelog.md\` + \`Handoff.md\`
Session entries 2026-04-17.

## Test plan

- [x] \`pnpm lint\` sin errores (pura doc)
- [ ] Review manual de la redacción de las 4 secciones
- [ ] Vercel preview pass (trivial para doc changes)

## Impacto

- Próxima sesión multi-agente tiene playbook canónico
- Próximo flake heredado en CI tiene protocolo claro (no más admin overrides normalizados)
- Próximo rebase con commit ajeno en base tiene comando canónico
- Next worktree inheriting won't blind-reinstall node_modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)