### PR TITLE
fix(nexa): propagate rootCauseNarrative through UI mappers

### DIFF
--- a/src/components/agency/IcoAdvisoryBlock.tsx
+++ b/src/components/agency/IcoAdvisoryBlock.tsx
@@ -15,6 +15,7 @@ const IcoAdvisoryBlock = ({ aiLlm }: Props) => {
     metricId: item.metricName,
     severity: item.severity,
     explanation: item.explanationSummary,
+    rootCauseNarrative: item.rootCauseNarrative,
     recommendedAction: item.recommendedAction
   }))
 

--- a/src/components/greenhouse/NexaInsightsBlock.tsx
+++ b/src/components/greenhouse/NexaInsightsBlock.tsx
@@ -29,7 +29,7 @@ export type NexaInsightItem = {
   metricId: string
   severity: string | null
   explanation: string | null
-  rootCauseNarrative?: string | null
+  rootCauseNarrative: string | null
   recommendedAction: string | null
 }
 

--- a/src/lib/home/get-home-snapshot.ts
+++ b/src/lib/home/get-home-snapshot.ts
@@ -41,6 +41,7 @@ const mapHomeInsight = (row: {
   metricName: string
   severity: string | null
   explanationSummary: string | null
+  rootCauseNarrative: string | null
   recommendedAction: string | null
 }): HomeNexaInsightItem => ({
   id: row.enrichmentId,
@@ -48,6 +49,7 @@ const mapHomeInsight = (row: {
   metricId: row.metricName,
   severity: row.severity,
   explanation: row.explanationSummary,
+  rootCauseNarrative: row.rootCauseNarrative,
   recommendedAction: row.recommendedAction
 })
 

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -31,6 +31,7 @@ export interface HomeNexaInsightItem {
   metricId: string
   severity: string | null
   explanation: string | null
+  rootCauseNarrative: string | null
   recommendedAction: string | null
 }
 


### PR DESCRIPTION
## Summary

Cierra el gap que impedía que \"Ver causa raíz\" apareciera en **Agency** y **Home**, a pesar de que [PR #63](https://github.com/efeoncepro/greenhouse-eo/pull/63) ya había:

- ✅ Extendido el reader para incluir \`root_cause_narrative\` en el SELECT
- ✅ Agregado el campo a 7 tipos de item (\`AgencyAiLlmSummaryItem\`, \`MemberNexaInsightItem\`, \`SpaceNexaInsightItem\`, \`FinanceNexaInsightItem\`, etc.)
- ✅ Cableado el componente \`NexaInsightRootCauseSection\` en \`NexaInsightsBlock\`

### Root cause del bug

Tres mappers entre el reader y \`NexaInsightItem\` tiraban el campo silenciosamente porque en \`NexaInsightsBlock\` el field estaba declarado como **opcional**. TypeScript no flaggeaba que faltaba en el mapper.

| Archivo | Gap |
|---|---|
| [src/components/agency/IcoAdvisoryBlock.tsx:12](src/components/agency/IcoAdvisoryBlock.tsx#L12) | Mapper Agency no incluía \`rootCauseNarrative\` |
| [src/lib/home/get-home-snapshot.ts:38](src/lib/home/get-home-snapshot.ts#L38) | Mapper Home + row type omiten el campo |
| [src/types/home.ts:28](src/types/home.ts#L28) | \`HomeNexaInsightItem\` no declaraba el campo |

**Finance dashboard** funcionaba OK porque hace cast directo del JSON API al type (\`nexaData.insights as NexaInsightItem[]\`), no re-mapping.

### Verificación en PG (staging)

Consulté \`greenhouse_serving.ico_ai_signal_enrichments\`:

\`\`\`
=== Lifetime breakdown ===
  total=15  populated=15  null_or_empty=0

=== Sample content (April 2026) ===
  ftr_pct  sev=critical  exp=259  rcn=334  ← Sky Airline
  otd_pct  sev=warning   exp=220  rcn=440  ← Efeonce
\`\`\`

Los **15/15 enrichments** de la tabla tienen \`root_cause_narrative\` poblado con contenido sustantivo. El problema era puramente el display path.

## Cambios

- Agregar \`rootCauseNarrative: item.rootCauseNarrative\` al mapper de \`IcoAdvisoryBlock\`
- Agregar \`rootCauseNarrative: string | null\` a \`HomeNexaInsightItem\` + mapper \`mapHomeInsight\`
- Promover \`NexaInsightItem.rootCauseNarrative\` de opcional a **required nullable** para que TypeScript force a futuros consumers a pasar el campo

## Test plan

- [x] \`pnpm lint\` ✓
- [x] \`pnpm tsc --noEmit\` ✓
- [x] \`pnpm test\` ✓ (1269 pass, 2 skipped, 0 failed)
- [ ] Preview deploy + visual check en \`/agency?tab=ico\`: \"Ver causa raíz\" toggle aparece
- [ ] Preview deploy + visual check en \`/home\`: mismo toggle aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)