### PR TITLE
fix: preserve Nexa insights history

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026-04-17
 
+### 2026-04-17 — Nexa Insights deja de perder historial semanal al cambiar el set actual de anomalías
+
+- Se agrega `greenhouse_serving.ico_ai_signal_enrichment_history` como archivo append-only de enrichments LLM; `ico_ai_signal_enrichments` se mantiene como snapshot current-state.
+- Los timelines de Agency, Home, Space 360 y Person 360 pasan a leer historial deduplicado por `enrichment_id`, así que una señal que desaparece del mes actual sigue viva en Historial.
+- El weekly digest ahora se arma desde ese historial deduplicado y ya no depende solo del snapshot vigente.
+- Se agrega replay histórico `historyOnly` con `asOfTime` y script `scripts/backfill-ico-llm-history.ts`; se recuperó el tramo replayable de abril 2026 (`2026-04-15` a `2026-04-17`) y quedó confirmado que `2026-04-01` a `2026-04-10 13:17 UTC` ya no es recuperable vía BigQuery time travel.
+
 ### 2026-04-17 — Nexa Insights: Historial extendido a Home, Space 360 y Person 360
 
 - Las 4 superficies Nexa (Agency, Home, Space 360, Person 360) ahora tienen toggle Recientes/Historial.

--- a/docs/architecture/GREENHOUSE_NEXA_INSIGHTS_LAYER_V1.md
+++ b/docs/architecture/GREENHOUSE_NEXA_INSIGHTS_LAYER_V1.md
@@ -1,5 +1,17 @@
 # Greenhouse — Nexa Insights Layer Architecture
 
+## Delta 2026-04-17 — Historial advisory append-only para timeline y weekly digest
+
+- Runtime activo:
+  - Nuevo archivo histórico `greenhouse_serving.ico_ai_signal_enrichment_history` con escritura append-only por run de LLM
+  - `ico_ai_signal_enrichments` se mantiene como snapshot current-state del período activo; no cambia el contrato de las surfaces "Recientes"
+  - `readAgencyAiLlmTimeline`, `readMemberAiLlmTimeline` y `readSpaceAiLlmTimeline` ahora leen desde historial, deduplicado por `enrichment_id` con `DISTINCT ON`
+  - `src/lib/nexa/digest/build-weekly-digest.ts` ahora arma el corte semanal desde historial deduplicado, no desde el snapshot vigente
+- Contrato operativo:
+  - una señal que desaparece del set actual por mejora operativa deja de verse en "Recientes", pero sigue viva en timeline y en el weekly digest de su ventana histórica
+  - reruns del mismo enrichment no duplican timeline/digest: el consumer colapsa a la última versión por `enrichment_id`
+  - esto evita pérdida silenciosa de contexto semanal/mensual en People, Space 360, Home y Agency
+
 ## Delta 2026-04-17 — Historial activado en las 4 superficies Nexa (Agency, Home, Space 360, Person 360)
 
 - Runtime activo:

--- a/docs/architecture/Greenhouse_ICO_Engine_v1.md
+++ b/docs/architecture/Greenhouse_ICO_Engine_v1.md
@@ -1,8 +1,15 @@
 # EFEONCE GREENHOUSE™ — ICO Engine
 
+## Delta 2026-04-17 — Nexa Insights preserva historial advisory con archive append-only
+
+- Nuevo archivo `greenhouse_serving.ico_ai_signal_enrichment_history` para conservar cada corrida LLM sin sobrescribirla
+- `readAgencyAiLlmTimeline(limit=20)` y los timelines scoped ahora leen desde historial deduplicado por `enrichment_id`, no desde `greenhouse_serving.ico_ai_signal_enrichments`
+- `src/lib/nexa/digest/build-weekly-digest.ts` consume el mismo historial deduplicado para no perder advisories cuando cambian las anomalías del período
+- Se agrega replay histórico `historyOnly` con `asOfTime` en `materializeAiLlmEnrichments()` y script operativo `scripts/backfill-ico-llm-history.ts`
+
 ## Delta 2026-04-17 — Nexa Insights gana vista Historial (timeline cross-period) sobre el mismo serving layer
 
-- Reader nuevo: `readAgencyAiLlmTimeline(limit=20)` en `src/lib/ico-engine/ai/llm-enrichment-reader.ts` — SELECT sin filtro de período sobre `greenhouse_serving.ico_ai_signal_enrichments`, ordenado por `processed_at DESC`, status='succeeded' only
+- Reader nuevo: `readAgencyAiLlmTimeline(limit=20)` en `src/lib/ico-engine/ai/llm-enrichment-reader.ts` — SELECT sin filtro de período sobre el historial advisory deduplicado, ordenado por `processed_at DESC`, status='succeeded' only
 - `readAgencyAiLlmSummary` fetchea current-period + timeline en paralelo (Promise.all) — sin impacto de latencia percibido
 - `AgencyAiLlmSummary.timeline: AgencyAiLlmSummaryItem[]` — extensión retrocompatible del contrato
 - UI: `NexaInsightsBlock` incorpora toggle Recientes/Historial (solo visible si hay timeline data); nueva `NexaInsightsTimeline.tsx` agrupa por día con MUI Lab Timeline

--- a/docs/documentation/delivery/nexa-insights-digest-semanal.md
+++ b/docs/documentation/delivery/nexa-insights-digest-semanal.md
@@ -3,7 +3,7 @@
 > **Tipo de documento:** Documentacion funcional (lenguaje simple)
 > **Version:** 1.0
 > **Creado:** 2026-04-16 por Codex
-> **Ultima actualizacion:** 2026-04-16 por Codex
+> **Ultima actualizacion:** 2026-04-17 por Codex
 > **Documentacion tecnica:** [GREENHOUSE_NEXA_INSIGHTS_LAYER_V1.md](../../architecture/GREENHOUSE_NEXA_INSIGHTS_LAYER_V1.md), [GREENHOUSE_CLOUD_INFRASTRUCTURE_V1.md](../../architecture/GREENHOUSE_CLOUD_INFRASTRUCTURE_V1.md), [GREENHOUSE_EMAIL_CATALOG_V1.md](../../architecture/GREENHOUSE_EMAIL_CATALOG_V1.md)
 
 # Nexa Insights — Digest Semanal para Liderazgo
@@ -64,13 +64,14 @@ El digest no calcula metricas inline dentro del correo ni corre analisis nuevos 
 
 Reutiliza:
 
-- enrichments ya materializados en `greenhouse_serving.ico_ai_signal_enrichments`
+- enrichments historicos ya materializados en `greenhouse_serving.ico_ai_signal_enrichment_history`
+- deduplicacion por `enrichment_id` para no repetir reruns del mismo advisory
 - ranking canonico de Nexa:
   - `critical > warning > info`
   - luego `quality_score DESC`
   - luego `processed_at DESC`
 
-Esto mantiene el correo alineado con lo que ya consume el portal en `Pulse`, `Space 360`, `Person 360` y el workspace de agency.
+Esto mantiene el correo alineado con lo que ya consume el portal en `Pulse`, `Space 360`, `Person 360` y el workspace de agency, sin perder señales que ya salieron del snapshot actual del mes.
 
 ---
 

--- a/migrations/20260417131401099_nexa-advisory-history-serving.sql
+++ b/migrations/20260417131401099_nexa-advisory-history-serving.sql
@@ -1,0 +1,131 @@
+-- Up Migration
+SET search_path = greenhouse_serving, greenhouse_core, public;
+
+CREATE TABLE IF NOT EXISTS greenhouse_serving.ico_ai_signal_enrichment_history (
+  history_id            TEXT PRIMARY KEY,
+  enrichment_id         TEXT NOT NULL,
+  run_id                TEXT NOT NULL,
+  signal_id             TEXT NOT NULL,
+  space_id              TEXT NOT NULL,
+  member_id             TEXT,
+  project_id            TEXT,
+  signal_type           TEXT NOT NULL,
+  metric_name           TEXT NOT NULL,
+  period_year           INT NOT NULL,
+  period_month          INT NOT NULL,
+  severity              TEXT,
+  quality_score         NUMERIC(6, 2),
+  explanation_summary   TEXT,
+  root_cause_narrative  TEXT,
+  recommended_action    TEXT,
+  explanation_json      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  model_id              TEXT NOT NULL,
+  prompt_version        TEXT NOT NULL,
+  prompt_hash           TEXT,
+  confidence            NUMERIC(6, 4),
+  tokens_in             INT,
+  tokens_out            INT,
+  latency_ms            INT,
+  status                TEXT NOT NULL,
+  error_message         TEXT,
+  processed_at          TIMESTAMPTZ NOT NULL,
+  source                TEXT NOT NULL DEFAULT 'ico_engine.ai_signal_enrichment_history',
+  synced_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ico_ai_signal_enrichment_history_enrichment
+  ON greenhouse_serving.ico_ai_signal_enrichment_history (enrichment_id, processed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ico_ai_signal_enrichment_history_space
+  ON greenhouse_serving.ico_ai_signal_enrichment_history (space_id, processed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ico_ai_signal_enrichment_history_member
+  ON greenhouse_serving.ico_ai_signal_enrichment_history (member_id, processed_at DESC)
+  WHERE member_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ico_ai_signal_enrichment_history_status
+  ON greenhouse_serving.ico_ai_signal_enrichment_history (status, processed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ico_ai_signal_enrichment_history_period
+  ON greenhouse_serving.ico_ai_signal_enrichment_history (
+    period_year DESC,
+    period_month DESC,
+    processed_at DESC
+  );
+
+INSERT INTO greenhouse_serving.ico_ai_signal_enrichment_history (
+  history_id,
+  enrichment_id,
+  run_id,
+  signal_id,
+  space_id,
+  member_id,
+  project_id,
+  signal_type,
+  metric_name,
+  period_year,
+  period_month,
+  severity,
+  quality_score,
+  explanation_summary,
+  root_cause_narrative,
+  recommended_action,
+  explanation_json,
+  model_id,
+  prompt_version,
+  prompt_hash,
+  confidence,
+  tokens_in,
+  tokens_out,
+  latency_ms,
+  status,
+  error_message,
+  processed_at,
+  source,
+  synced_at
+)
+SELECT
+  ('EO-AIH-' || UPPER(SUBSTRING(MD5(COALESCE(run_id, '') || '|' || enrichment_id) FROM 1 FOR 8))) AS history_id,
+  enrichment_id,
+  run_id,
+  signal_id,
+  space_id,
+  member_id,
+  project_id,
+  signal_type,
+  metric_name,
+  period_year,
+  period_month,
+  severity,
+  quality_score,
+  explanation_summary,
+  root_cause_narrative,
+  recommended_action,
+  explanation_json,
+  model_id,
+  prompt_version,
+  prompt_hash,
+  confidence,
+  tokens_in,
+  tokens_out,
+  latency_ms,
+  status,
+  error_message,
+  processed_at,
+  'ico_engine.ai_signal_enrichment_history',
+  COALESCE(synced_at, NOW())
+FROM greenhouse_serving.ico_ai_signal_enrichments
+ON CONFLICT (history_id) DO NOTHING;
+
+GRANT SELECT ON greenhouse_serving.ico_ai_signal_enrichment_history TO greenhouse_runtime;
+GRANT SELECT, INSERT, UPDATE, DELETE ON greenhouse_serving.ico_ai_signal_enrichment_history TO greenhouse_migrator;
+GRANT SELECT, INSERT, UPDATE, DELETE ON greenhouse_serving.ico_ai_signal_enrichment_history TO greenhouse_app;
+
+-- Down Migration
+SET search_path = greenhouse_serving, greenhouse_core, public;
+
+REVOKE ALL ON greenhouse_serving.ico_ai_signal_enrichment_history FROM greenhouse_app;
+REVOKE ALL ON greenhouse_serving.ico_ai_signal_enrichment_history FROM greenhouse_migrator;
+REVOKE ALL ON greenhouse_serving.ico_ai_signal_enrichment_history FROM greenhouse_runtime;
+
+DROP TABLE IF EXISTS greenhouse_serving.ico_ai_signal_enrichment_history;

--- a/scripts/backfill-ico-llm-history.ts
+++ b/scripts/backfill-ico-llm-history.ts
@@ -1,0 +1,133 @@
+import { query } from '@/lib/db'
+import { materializeAiLlmEnrichments } from '@/lib/ico-engine/ai/llm-enrichment-worker'
+
+interface ReplayRunRow extends Record<string, unknown> {
+  run_id: string
+  space_id: string | null
+  period_year: number
+  period_month: number
+  status: string
+  signals_enriched: number
+  started_at: string
+  completed_at: string | null
+}
+
+const getArgValue = (name: string) => {
+  const index = process.argv.findIndex(arg => arg === `--${name}`)
+
+  return index >= 0 ? process.argv[index + 1] ?? null : null
+}
+
+const hasFlag = (name: string) => process.argv.includes(`--${name}`)
+
+const parseRequiredNumber = (name: string, fallback: number) => {
+  const raw = getArgValue(name)
+  const candidate = raw ? Number(raw) : fallback
+
+  if (!Number.isInteger(candidate)) {
+    throw new Error(`Invalid --${name} value: ${raw}`)
+  }
+
+  return candidate
+}
+
+const main = async () => {
+  const now = new Date()
+  const defaultYear = now.getUTCFullYear()
+  const defaultMonth = now.getUTCMonth() + 1
+  const periodYear = parseRequiredNumber('year', defaultYear)
+  const periodMonth = parseRequiredNumber('month', defaultMonth)
+  const from = getArgValue('from') ?? `${periodYear}-${String(periodMonth).padStart(2, '0')}-01T00:00:00.000Z`
+  const to = getArgValue('to') ?? now.toISOString()
+  const dryRun = hasFlag('dry-run')
+
+  const runs = await query<ReplayRunRow>(
+    `
+      SELECT
+        run_id,
+        space_id,
+        period_year,
+        period_month,
+        status,
+        signals_enriched,
+        started_at::text AS started_at,
+        completed_at::text AS completed_at
+      FROM greenhouse_serving.ico_ai_enrichment_runs
+      WHERE period_year = $1
+        AND period_month = $2
+        AND signals_enriched > 0
+        AND COALESCE(completed_at, started_at) >= $3::timestamptz
+        AND COALESCE(completed_at, started_at) <= $4::timestamptz
+      ORDER BY COALESCE(completed_at, started_at) ASC, space_id NULLS FIRST, run_id ASC
+    `,
+    [periodYear, periodMonth, from, to]
+  )
+
+  console.log(
+    `[backfill-ico-llm-history] period=${periodYear}-${String(periodMonth).padStart(2, '0')} ` +
+      `window=${from}..${to} runs=${runs.length} dryRun=${dryRun}`
+  )
+
+  if (runs.length === 0) {
+    return
+  }
+
+  let recovered = 0
+  let skippedRetention = 0
+  let failed = 0
+
+  for (const run of runs) {
+    const asOfTime = run.completed_at ?? run.started_at
+    const scopeLabel = run.space_id ? `space=${run.space_id}` : 'scope=global'
+
+    console.log(
+      `[backfill-ico-llm-history] replay ${run.run_id} ${scopeLabel} asOf=${asOfTime} enriched=${run.signals_enriched}`
+    )
+
+    if (dryRun) {
+      continue
+    }
+
+    try {
+      const result = await materializeAiLlmEnrichments({
+        periodYear: run.period_year,
+        periodMonth: run.period_month,
+        spaceId: run.space_id,
+        triggerEventId: run.run_id,
+        triggerType: 'historical_backfill',
+        asOfTime,
+        historyOnly: true
+      })
+
+      recovered += result.succeeded
+
+      console.log(
+        `[backfill-ico-llm-history] ok ${run.run_id} -> succeeded=${result.succeeded} failed=${result.failed} skipped=${result.skipped}`
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      if (message.includes('Invalid time travel timestamp')) {
+        skippedRetention += 1
+        console.warn(`[backfill-ico-llm-history] skipped retention boundary for ${run.run_id}: ${message}`)
+        continue
+      }
+
+      failed += 1
+      console.error(`[backfill-ico-llm-history] failed ${run.run_id}: ${message}`)
+    }
+  }
+
+  console.log(
+    `[backfill-ico-llm-history] done recovered=${recovered} skippedRetention=${skippedRetention} failed=${failed}`
+  )
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch(error => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })

--- a/src/lib/ico-engine/ai/llm-enrichment-reader.test.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-reader.test.ts
@@ -8,7 +8,14 @@ vi.mock('@/lib/db', () => ({
   query: (...args: unknown[]) => mockQuery(...args)
 }))
 
-const { readMemberAiLlmSummary, readSpaceAiLlmSummary, readTopAiLlmEnrichments } = await import('./llm-enrichment-reader')
+const {
+  readAgencyAiLlmTimeline,
+  readMemberAiLlmSummary,
+  readMemberAiLlmTimeline,
+  readSpaceAiLlmSummary,
+  readSpaceAiLlmTimeline,
+  readTopAiLlmEnrichments
+} = await import('./llm-enrichment-reader')
 
 beforeEach(() => {
   mockQuery.mockReset()
@@ -157,11 +164,14 @@ describe('readMemberAiLlmSummary', () => {
     )
 
     const memberSql = mockQuery.mock.calls[1][0] as string
+    const memberTimelineSql = mockQuery.mock.calls[3][0] as string
 
     expect(memberSql).toContain("CASE COALESCE(severity, '')")
     expect(memberSql).toContain("WHEN 'critical' THEN 0")
     expect(memberSql).toContain('quality_score DESC NULLS LAST')
     expect(memberSql).toContain('processed_at DESC')
+    expect(memberTimelineSql).toContain('greenhouse_serving.ico_ai_signal_enrichment_history')
+    expect(memberTimelineSql).toContain('DISTINCT ON (enrichment_id)')
 
     expect(result).toEqual({
       totalAnalyzed: 2,
@@ -247,11 +257,14 @@ describe('readSpaceAiLlmSummary', () => {
     )
 
     const spaceSql = mockQuery.mock.calls[1][0] as string
+    const spaceTimelineSql = mockQuery.mock.calls[3][0] as string
 
     expect(spaceSql).toContain("CASE COALESCE(severity, '')")
     expect(spaceSql).toContain("WHEN 'critical' THEN 0")
     expect(spaceSql).toContain('quality_score DESC NULLS LAST')
     expect(spaceSql).toContain('processed_at DESC')
+    expect(spaceTimelineSql).toContain('greenhouse_serving.ico_ai_signal_enrichment_history')
+    expect(spaceTimelineSql).toContain('DISTINCT ON (enrichment_id)')
 
     expect(result).toEqual({
       totalAnalyzed: 2,
@@ -271,5 +284,115 @@ describe('readSpaceAiLlmSummary', () => {
       ],
       timeline: []
     })
+  })
+})
+
+describe('timeline readers', () => {
+  it('reads the agency timeline from historical enrichments deduplicated by enrichment', async () => {
+    mockQuery.mockResolvedValue([
+      {
+        enrichment_id: 'EO-AIE-30',
+        signal_id: 'signal-30',
+        signal_type: 'root_cause',
+        space_id: 'space-9',
+        metric_name: 'ftr_pct',
+        severity: 'critical',
+        explanation_summary: 'Persisted in history',
+        recommended_action: 'Escalar',
+        processed_at: '2026-04-16T10:00:00.000Z'
+      }
+    ])
+
+    const result = await readAgencyAiLlmTimeline(10)
+    const sql = mockQuery.mock.calls[0][0] as string
+
+    expect(sql).toContain('greenhouse_serving.ico_ai_signal_enrichment_history')
+    expect(sql).toContain('DISTINCT ON (enrichment_id)')
+    expect(sql).toContain("WHERE status = 'succeeded'")
+
+    expect(result).toEqual([
+      {
+        enrichmentId: 'EO-AIE-30',
+        signalId: 'signal-30',
+        signalType: 'root_cause',
+        spaceId: 'space-9',
+        metricName: 'ftr_pct',
+        severity: 'critical',
+        qualityScore: null,
+        explanationSummary: 'Persisted in history',
+        rootCauseNarrative: null,
+        recommendedAction: 'Escalar',
+        confidence: null,
+        processedAt: '2026-04-16T10:00:00.000Z'
+      }
+    ])
+  })
+
+  it('reads the member timeline from historical enrichments deduplicated by enrichment', async () => {
+    mockQuery.mockResolvedValue([
+      {
+        enrichment_id: 'EO-AIE-31',
+        signal_type: 'recommendation',
+        metric_name: 'rpa_avg',
+        severity: 'warning',
+        explanation_summary: 'Historial de persona',
+        recommended_action: null,
+        processed_at: '2026-04-16T09:30:00.000Z'
+      }
+    ])
+
+    const result = await readMemberAiLlmTimeline('member-42', 10)
+    const sql = mockQuery.mock.calls[0][0] as string
+
+    expect(sql).toContain('greenhouse_serving.ico_ai_signal_enrichment_history')
+    expect(sql).toContain('member_id = $1')
+    expect(sql).toContain('DISTINCT ON (enrichment_id)')
+
+    expect(result).toEqual([
+      {
+        id: 'EO-AIE-31',
+        signalType: 'recommendation',
+        metricId: 'rpa_avg',
+        severity: 'warning',
+        explanation: 'Historial de persona',
+        rootCauseNarrative: null,
+        recommendedAction: null,
+        processedAt: '2026-04-16T09:30:00.000Z'
+      }
+    ])
+  })
+
+  it('reads the space timeline from historical enrichments deduplicated by enrichment', async () => {
+    mockQuery.mockResolvedValue([
+      {
+        enrichment_id: 'EO-AIE-32',
+        signal_type: 'anomaly',
+        metric_name: 'otd_pct',
+        severity: 'critical',
+        explanation_summary: 'Historial de space',
+        recommended_action: 'Ajustar staffing',
+        processed_at: '2026-04-16T08:45:00.000Z'
+      }
+    ])
+
+    const result = await readSpaceAiLlmTimeline('space-42', 10)
+    const sql = mockQuery.mock.calls[0][0] as string
+
+    expect(sql).toContain('greenhouse_serving.ico_ai_signal_enrichment_history')
+    expect(sql).toContain('space_id = $1')
+    expect(sql).toContain('DISTINCT ON (enrichment_id)')
+
+    expect(result).toEqual([
+      {
+        id: 'EO-AIE-32',
+        signalType: 'anomaly',
+        metricId: 'otd_pct',
+        severity: 'critical',
+        explanation: 'Historial de space',
+        rootCauseNarrative: null,
+        recommendedAction: 'Ajustar staffing',
+        processedAt: '2026-04-16T08:45:00.000Z'
+      }
+    ])
   })
 })

--- a/src/lib/ico-engine/ai/llm-enrichment-reader.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-reader.ts
@@ -98,6 +98,37 @@ const mapSpaceInsightItem = (row: RawRow): SpaceNexaInsightItem => ({
 
 const TIMELINE_DEFAULT_LIMIT = 20
 const TIMELINE_MAX_LIMIT = 50
+const ENRICHMENT_HISTORY_TABLE = 'greenhouse_serving.ico_ai_signal_enrichment_history'
+
+const TIMELINE_SELECT_COLUMNS = `
+  enrichment_id,
+  signal_id,
+  space_id,
+  member_id,
+  project_id,
+  signal_type,
+  metric_name,
+  severity,
+  quality_score,
+  explanation_summary,
+  root_cause_narrative,
+  recommended_action,
+  confidence,
+  processed_at::text AS processed_at
+`
+
+const buildHistoricalTimelineQuery = (scopeSql: string) => `
+  SELECT ${TIMELINE_SELECT_COLUMNS}
+  FROM (
+    SELECT DISTINCT ON (enrichment_id) *
+    FROM ${ENRICHMENT_HISTORY_TABLE}
+    WHERE ${scopeSql}
+      AND status = 'succeeded'
+    ORDER BY enrichment_id, processed_at DESC
+  ) enrichments
+  ORDER BY processed_at DESC
+  LIMIT $2
+`
 
 export const readAgencyAiLlmTimeline = async (
   limit = TIMELINE_DEFAULT_LIMIT
@@ -106,9 +137,13 @@ export const readAgencyAiLlmTimeline = async (
 
   const rows = await query<RawRow>(
     `
-      SELECT *
-      FROM greenhouse_serving.ico_ai_signal_enrichments
-      WHERE status = 'succeeded'
+      SELECT ${TIMELINE_SELECT_COLUMNS}
+      FROM (
+        SELECT DISTINCT ON (enrichment_id) *
+        FROM ${ENRICHMENT_HISTORY_TABLE}
+        WHERE status = 'succeeded'
+        ORDER BY enrichment_id, processed_at DESC
+      ) enrichments
       ORDER BY processed_at DESC
       LIMIT $1
     `,
@@ -358,14 +393,7 @@ export const readMemberAiLlmTimeline = async (
   const boundedLimit = Math.min(Math.max(Math.trunc(limit), 1), TIMELINE_MAX_LIMIT)
 
   const rows = await query<RawRow>(
-    `
-      SELECT *
-      FROM greenhouse_serving.ico_ai_signal_enrichments
-      WHERE member_id = $1
-        AND status = 'succeeded'
-      ORDER BY processed_at DESC
-      LIMIT $2
-    `,
+    buildHistoricalTimelineQuery('member_id = $1'),
     [memberId, boundedLimit]
   ).catch(() => [])
 
@@ -379,14 +407,7 @@ export const readSpaceAiLlmTimeline = async (
   const boundedLimit = Math.min(Math.max(Math.trunc(limit), 1), TIMELINE_MAX_LIMIT)
 
   const rows = await query<RawRow>(
-    `
-      SELECT *
-      FROM greenhouse_serving.ico_ai_signal_enrichments
-      WHERE space_id = $1
-        AND status = 'succeeded'
-      ORDER BY processed_at DESC
-      LIMIT $2
-    `,
+    buildHistoricalTimelineQuery('space_id = $1'),
     [spaceId, boundedLimit]
   ).catch(() => [])
 

--- a/src/lib/ico-engine/ai/llm-enrichment-worker.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-worker.ts
@@ -16,6 +16,8 @@ import {
   ICO_LLM_PROMPT_VERSION,
   ICO_LLM_SUPPORTED_SIGNAL_TYPES,
   stableEnrichmentId,
+  stableEnrichmentHistoryId,
+  stableReplayRunId,
   stableRunId,
   toSerializableSignalSnapshot,
   type AiEnrichmentRunRecord,
@@ -29,6 +31,8 @@ export interface MaterializeAiLlmEnrichmentsInput {
   triggerEventId?: string | null
   triggerType?: string
   modelId?: string | null
+  asOfTime?: string | null
+  historyOnly?: boolean
 }
 
 export interface MaterializeAiLlmEnrichmentsResult {
@@ -42,6 +46,7 @@ export interface MaterializeAiLlmEnrichmentsResult {
 type BigQuerySignalRow = Record<string, unknown>
 
 const SUPPORTED_SIGNAL_TYPES = new Set<string>(ICO_LLM_SUPPORTED_SIGNAL_TYPES)
+const LLM_ENRICHMENT_TIMEOUT_MS = 60_000
 
 const toNumber = (value: unknown) => {
   if (typeof value === 'number') return Number.isFinite(value) ? value : null
@@ -166,6 +171,25 @@ const chunk = <T>(items: T[], size: number) => {
   return groups
 }
 
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`LLM enrichment timed out after ${timeoutMs}ms (${label})`))
+        }, timeoutMs)
+      })
+    ])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}
+
 const buildBaseRecord = (signal: AiSignalRecord, runId: string, promptHash: string, modelId: string): Omit<AiSignalEnrichmentRecord, 'qualityScore' | 'explanationSummary' | 'rootCauseNarrative' | 'recommendedAction' | 'explanationJson' | 'confidence' | 'tokensIn' | 'tokensOut' | 'latencyMs' | 'status' | 'errorMessage' | 'processedAt'> => ({
   enrichmentId: stableEnrichmentId(signal.signalId, promptHash),
   runId,
@@ -266,7 +290,113 @@ const deleteBigQueryCurrentState = async (input: {
   await bigQuery.query({ query: enrichmentDeleteQuery, params })
 }
 
-const persistServingState = async (records: AiSignalEnrichmentRecord[], run: AiEnrichmentRunRecord) => {
+const persistServingState = async (
+  records: AiSignalEnrichmentRecord[],
+  run: AiEnrichmentRunRecord,
+  options?: { historyOnly?: boolean }
+) => {
+  for (const record of records) {
+    await query(
+      `
+        INSERT INTO greenhouse_serving.ico_ai_signal_enrichment_history (
+          history_id,
+          enrichment_id,
+          run_id,
+          signal_id,
+          space_id,
+          member_id,
+          project_id,
+          signal_type,
+          metric_name,
+          period_year,
+          period_month,
+          severity,
+          quality_score,
+          explanation_summary,
+          root_cause_narrative,
+          recommended_action,
+          explanation_json,
+          model_id,
+          prompt_version,
+          prompt_hash,
+          confidence,
+          tokens_in,
+          tokens_out,
+          latency_ms,
+          status,
+          error_message,
+          processed_at,
+          synced_at
+        ) VALUES (
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+          $11, $12, $13, $14, $15, $16, $17::jsonb, $18, $19, $20,
+          $21, $22, $23, $24, $25, $26, $27, NOW()
+        )
+        ON CONFLICT (history_id) DO UPDATE SET
+          enrichment_id = EXCLUDED.enrichment_id,
+          run_id = EXCLUDED.run_id,
+          signal_id = EXCLUDED.signal_id,
+          space_id = EXCLUDED.space_id,
+          member_id = EXCLUDED.member_id,
+          project_id = EXCLUDED.project_id,
+          signal_type = EXCLUDED.signal_type,
+          metric_name = EXCLUDED.metric_name,
+          period_year = EXCLUDED.period_year,
+          period_month = EXCLUDED.period_month,
+          severity = EXCLUDED.severity,
+          quality_score = EXCLUDED.quality_score,
+          explanation_summary = EXCLUDED.explanation_summary,
+          root_cause_narrative = EXCLUDED.root_cause_narrative,
+          recommended_action = EXCLUDED.recommended_action,
+          explanation_json = EXCLUDED.explanation_json,
+          model_id = EXCLUDED.model_id,
+          prompt_version = EXCLUDED.prompt_version,
+          prompt_hash = EXCLUDED.prompt_hash,
+          confidence = EXCLUDED.confidence,
+          tokens_in = EXCLUDED.tokens_in,
+          tokens_out = EXCLUDED.tokens_out,
+          latency_ms = EXCLUDED.latency_ms,
+          status = EXCLUDED.status,
+          error_message = EXCLUDED.error_message,
+          processed_at = EXCLUDED.processed_at,
+          synced_at = NOW()
+      `,
+      [
+        stableEnrichmentHistoryId(record.runId, record.enrichmentId),
+        record.enrichmentId,
+        record.runId,
+        record.signalId,
+        record.spaceId,
+        record.memberId,
+        record.projectId,
+        record.signalType,
+        record.metricName,
+        record.periodYear,
+        record.periodMonth,
+        record.severity,
+        record.qualityScore,
+        record.explanationSummary,
+        record.rootCauseNarrative,
+        record.recommendedAction,
+        JSON.stringify(record.explanationJson),
+        record.modelId,
+        record.promptVersion,
+        record.promptHash,
+        record.confidence,
+        record.tokensIn,
+        record.tokensOut,
+        record.latencyMs,
+        record.status,
+        record.errorMessage,
+        record.processedAt
+      ]
+    )
+  }
+
+  if (options?.historyOnly) {
+    return
+  }
+
   if (run.spaceId) {
     await query(
       `
@@ -461,7 +591,8 @@ const buildFailedRecord = (
   promptHash: string,
   modelId: string,
   status: AiSignalEnrichmentRecord['status'],
-  errorMessage: string
+  errorMessage: string,
+  processedAt: string
 ): AiSignalEnrichmentRecord => ({
   ...buildBaseRecord(signal, runId, promptHash, modelId),
   qualityScore: null,
@@ -475,7 +606,7 @@ const buildFailedRecord = (
   latencyMs: null,
   status,
   errorMessage,
-  processedAt: new Date().toISOString()
+  processedAt
 })
 
 export const materializeAiLlmEnrichments = async (
@@ -487,13 +618,22 @@ export const materializeAiLlmEnrichments = async (
   const bigQuery = getBigQueryClient()
   const modelId = input.modelId?.trim() || ICO_LLM_DEFAULT_MODEL_ID
   const promptHash = buildIcoLlmPromptHash()
-  const runId = stableRunId(input.periodYear, input.periodMonth, promptHash)
+  const asOfTime = input.asOfTime?.trim() || null
+  const historyOnly = input.historyOnly === true
+
+  const runId =
+    historyOnly && asOfTime
+      ? stableReplayRunId(input.periodYear, input.periodMonth, promptHash, asOfTime, input.spaceId)
+      : stableRunId(input.periodYear, input.periodMonth, promptHash)
+
   const startedAt = new Date().toISOString()
+  const recordProcessedAt = asOfTime ?? startedAt
+  const systemTimeClause = asOfTime ? ' FOR SYSTEM_TIME AS OF TIMESTAMP(@asOfTime)' : ''
 
   const queryText = input.spaceId
     ? `
       SELECT *
-      FROM \`${projectId}.${ICO_DATASET}.ai_signals\`
+      FROM \`${projectId}.${ICO_DATASET}.ai_signals\`${systemTimeClause}
       WHERE period_year = @periodYear
         AND period_month = @periodMonth
         AND space_id = @spaceId
@@ -501,15 +641,15 @@ export const materializeAiLlmEnrichments = async (
     `
     : `
       SELECT *
-      FROM \`${projectId}.${ICO_DATASET}.ai_signals\`
+      FROM \`${projectId}.${ICO_DATASET}.ai_signals\`${systemTimeClause}
       WHERE period_year = @periodYear
         AND period_month = @periodMonth
       ORDER BY generated_at DESC, signal_id ASC
     `
 
   const params = input.spaceId
-    ? { periodYear: input.periodYear, periodMonth: input.periodMonth, spaceId: input.spaceId }
-    : { periodYear: input.periodYear, periodMonth: input.periodMonth }
+    ? { periodYear: input.periodYear, periodMonth: input.periodMonth, spaceId: input.spaceId, ...(asOfTime ? { asOfTime } : {}) }
+    : { periodYear: input.periodYear, periodMonth: input.periodMonth, ...(asOfTime ? { asOfTime } : {}) }
 
   const [rawRows] = await bigQuery.query({ query: queryText, params })
 
@@ -525,11 +665,19 @@ export const materializeAiLlmEnrichments = async (
     const batchResults = await Promise.all(
       signalBatch.map(async signal => {
         if (!signal.aiEligible) {
-          return buildFailedRecord(signal, runId, promptHash, modelId, 'skipped', 'Signal is not AI-eligible')
+          return buildFailedRecord(signal, runId, promptHash, modelId, 'skipped', 'Signal is not AI-eligible', recordProcessedAt)
         }
 
         if (!SUPPORTED_SIGNAL_TYPES.has(signal.signalType)) {
-          return buildFailedRecord(signal, runId, promptHash, modelId, 'skipped', `Unsupported signal type: ${signal.signalType}`)
+          return buildFailedRecord(
+            signal,
+            runId,
+            promptHash,
+            modelId,
+            'skipped',
+            `Unsupported signal type: ${signal.signalType}`,
+            recordProcessedAt
+          )
         }
 
         try {
@@ -537,13 +685,17 @@ export const materializeAiLlmEnrichments = async (
             ? getResolvedProjectDisplay(resolvedContext.projectResolutions, signal.spaceId, signal.projectId)
             : null
 
-          const generated = await generateAiSignalEnrichment({
-            signal,
-            modelId,
-            promptVersion: ICO_LLM_PROMPT_VERSION,
-            promptHash,
-            resolvedContext
-          })
+          const generated = await withTimeout(
+            generateAiSignalEnrichment({
+              signal,
+              modelId,
+              promptVersion: ICO_LLM_PROMPT_VERSION,
+              promptHash,
+              resolvedContext
+            }),
+            LLM_ENRICHMENT_TIMEOUT_MS,
+            signal.signalId
+          )
 
           return {
             ...buildBaseRecord(signal, runId, promptHash, generated.modelId),
@@ -571,7 +723,7 @@ export const materializeAiLlmEnrichments = async (
             latencyMs: generated.latencyMs,
             status: 'succeeded' as const,
             errorMessage: null,
-            processedAt: new Date().toISOString()
+            processedAt: recordProcessedAt
           }
         } catch (error) {
           return buildFailedRecord(
@@ -580,7 +732,8 @@ export const materializeAiLlmEnrichments = async (
             promptHash,
             modelId,
             'failed',
-            error instanceof Error ? error.message : 'Unknown LLM generation error'
+            error instanceof Error ? error.message : 'Unknown LLM generation error',
+            recordProcessedAt
           )
         }
       })
@@ -624,46 +777,50 @@ export const materializeAiLlmEnrichments = async (
   }
 
   // BigQuery write: best-effort. If streaming buffer blocks DELETE, continue with PostgreSQL serving.
-  try {
-    await deleteBigQueryCurrentState({
-      projectId,
-      periodYear: input.periodYear,
-      periodMonth: input.periodMonth,
-      spaceId: input.spaceId
-    })
+  if (!historyOnly) {
+    try {
+      await deleteBigQueryCurrentState({
+        projectId,
+        periodYear: input.periodYear,
+        periodMonth: input.periodMonth,
+        spaceId: input.spaceId
+      })
 
-    if (records.length > 0) {
-      await bigQuery.dataset(ICO_DATASET).table('ai_signal_enrichments').insert(records.map(toBigQueryEnrichmentRow))
+      if (records.length > 0) {
+        await bigQuery.dataset(ICO_DATASET).table('ai_signal_enrichments').insert(records.map(toBigQueryEnrichmentRow))
+      }
+
+      await bigQuery.dataset(ICO_DATASET).table('ai_enrichment_runs').insert([toBigQueryRunRow(run)])
+    } catch (bqError) {
+      console.warn('[llm-enrichment] BigQuery write skipped (streaming buffer or transient error), persisting to PostgreSQL serving:', bqError instanceof Error ? bqError.message : bqError)
     }
-
-    await bigQuery.dataset(ICO_DATASET).table('ai_enrichment_runs').insert([toBigQueryRunRow(run)])
-  } catch (bqError) {
-    console.warn('[llm-enrichment] BigQuery write skipped (streaming buffer or transient error), persisting to PostgreSQL serving:', bqError instanceof Error ? bqError.message : bqError)
   }
 
-  await persistServingState(records, run)
+  await persistServingState(records, run, { historyOnly })
 
-  await publishOutboxEvent({
-    aggregateType: AGGREGATE_TYPES.icoAiLlmEnrichments,
-    aggregateId: input.spaceId
-      ? `ico-ai-llm-${input.periodYear}-${String(input.periodMonth).padStart(2, '0')}-${input.spaceId}`
-      : `ico-ai-llm-${input.periodYear}-${String(input.periodMonth).padStart(2, '0')}`,
-    eventType: EVENT_TYPES.icoAiLlmEnrichmentsMaterialized,
-    payload: {
-      runId,
-      periodYear: input.periodYear,
-      periodMonth: input.periodMonth,
-      spaceId: input.spaceId ?? null,
-      signalsSeen: run.signalsSeen,
-      signalsEnriched: run.signalsEnriched,
-      signalsFailed: run.signalsFailed,
-      skipped,
-      modelId,
-      promptVersion: ICO_LLM_PROMPT_VERSION,
-      promptHash,
-      status: run.status
-    }
-  }).catch(() => {})
+  if (!historyOnly) {
+    await publishOutboxEvent({
+      aggregateType: AGGREGATE_TYPES.icoAiLlmEnrichments,
+      aggregateId: input.spaceId
+        ? `ico-ai-llm-${input.periodYear}-${String(input.periodMonth).padStart(2, '0')}-${input.spaceId}`
+        : `ico-ai-llm-${input.periodYear}-${String(input.periodMonth).padStart(2, '0')}`,
+      eventType: EVENT_TYPES.icoAiLlmEnrichmentsMaterialized,
+      payload: {
+        runId,
+        periodYear: input.periodYear,
+        periodMonth: input.periodMonth,
+        spaceId: input.spaceId ?? null,
+        signalsSeen: run.signalsSeen,
+        signalsEnriched: run.signalsEnriched,
+        signalsFailed: run.signalsFailed,
+        skipped,
+        modelId,
+        promptVersion: ICO_LLM_PROMPT_VERSION,
+        promptHash,
+        status: run.status
+      }
+    }).catch(() => {})
+  }
 
   return {
     run,

--- a/src/lib/ico-engine/ai/llm-types.ts
+++ b/src/lib/ico-engine/ai/llm-types.ts
@@ -266,5 +266,17 @@ export const toSerializableSignalSnapshot = (signal: AiSignalRecord) => ({
 export const stableEnrichmentId = (signalId: string, promptHash: string) =>
   `EO-AIE-${createHash('sha1').update(`${signalId}|${promptHash}`).digest('hex').slice(0, 8)}`.toUpperCase()
 
+export const stableEnrichmentHistoryId = (runId: string, enrichmentId: string) =>
+  `EO-AIH-${createHash('sha1').update(`${runId}|${enrichmentId}`).digest('hex').slice(0, 8)}`.toUpperCase()
+
+export const stableReplayRunId = (
+  periodYear: number,
+  periodMonth: number,
+  promptHash: string,
+  asOfTime: string,
+  spaceId?: string | null
+) =>
+  `EO-AIR-${createHash('sha1').update(`${periodYear}-${periodMonth}|${promptHash}|${asOfTime}|${spaceId ?? 'all'}|replay`).digest('hex').slice(0, 8)}`.toUpperCase()
+
 export const stableRunId = (periodYear: number, periodMonth: number, promptHash: string) =>
   `EO-AIR-${createHash('sha1').update(`${periodYear}-${periodMonth}|${promptHash}|${Date.now()}`).digest('hex').slice(0, 8)}`.toUpperCase()

--- a/src/lib/nexa/digest/build-weekly-digest.ts
+++ b/src/lib/nexa/digest/build-weekly-digest.ts
@@ -207,8 +207,41 @@ export const buildWeeklyDigest = async (
   const portalUrl = resolvePortalUrl()
   const db = await getDb()
 
+  const enrichmentHistoryWindow = sql<{
+    enrichment_id: string
+    space_id: string
+    signal_type: string
+    metric_name: string
+    severity: string | null
+    quality_score: number | string | null
+    explanation_summary: string | null
+    recommended_action: string | null
+    root_cause_narrative: string | null
+    confidence: number | string | null
+    processed_at: Date
+    status: string
+  }>`(
+    SELECT DISTINCT ON (enrichment_id)
+      enrichment_id,
+      space_id,
+      signal_type,
+      metric_name,
+      severity,
+      quality_score,
+      explanation_summary,
+      recommended_action,
+      root_cause_narrative,
+      confidence,
+      processed_at,
+      status
+    FROM greenhouse_serving.ico_ai_signal_enrichment_history
+    WHERE processed_at >= ${window.startAt}
+      AND processed_at < ${window.endAt}
+    ORDER BY enrichment_id, processed_at DESC
+  )`.as('enrich')
+
   const rows = await db
-    .selectFrom('greenhouse_serving.ico_ai_signal_enrichments as enrich')
+    .selectFrom(enrichmentHistoryWindow)
     .innerJoin('greenhouse_core.spaces as spaces', join =>
       join
         .onRef('spaces.space_id', '=', 'enrich.space_id')
@@ -231,8 +264,6 @@ export const buildWeeklyDigest = async (
       sql<string>`enrich.processed_at::text`.as('processed_at')
     ])
     .where('enrich.status', '=', 'succeeded')
-    .where('enrich.processed_at', '>=', window.startAt)
-    .where('enrich.processed_at', '<', window.endAt)
     .orderBy(sql`
       CASE COALESCE(enrich.severity, '')
         WHEN 'critical' THEN 0

--- a/src/types/db.d.ts
+++ b/src/types/db.d.ts
@@ -3381,6 +3381,38 @@ export interface GreenhouseServingIcoAiEnrichmentRuns {
   trigger_type: string;
 }
 
+export interface GreenhouseServingIcoAiSignalEnrichmentHistory {
+  confidence: Numeric | null;
+  enrichment_id: string;
+  error_message: string | null;
+  explanation_json: Generated<Json>;
+  explanation_summary: string | null;
+  history_id: string;
+  latency_ms: number | null;
+  member_id: string | null;
+  metric_name: string;
+  model_id: string;
+  period_month: number;
+  period_year: number;
+  processed_at: Timestamp;
+  project_id: string | null;
+  prompt_hash: string | null;
+  prompt_version: string;
+  quality_score: Numeric | null;
+  recommended_action: string | null;
+  root_cause_narrative: string | null;
+  run_id: string;
+  severity: string | null;
+  signal_id: string;
+  signal_type: string;
+  source: Generated<string>;
+  space_id: string;
+  status: string;
+  synced_at: Generated<Timestamp>;
+  tokens_in: number | null;
+  tokens_out: number | null;
+}
+
 export interface GreenhouseServingIcoAiSignalEnrichments {
   confidence: Numeric | null;
   enrichment_id: string;
@@ -4807,6 +4839,7 @@ export interface DB {
   "greenhouse_serving.finance_ai_signal_enrichments": GreenhouseServingFinanceAiSignalEnrichments;
   "greenhouse_serving.finance_ai_signals": GreenhouseServingFinanceAiSignals;
   "greenhouse_serving.ico_ai_enrichment_runs": GreenhouseServingIcoAiEnrichmentRuns;
+  "greenhouse_serving.ico_ai_signal_enrichment_history": GreenhouseServingIcoAiSignalEnrichmentHistory;
   "greenhouse_serving.ico_ai_signal_enrichments": GreenhouseServingIcoAiSignalEnrichments;
   "greenhouse_serving.ico_ai_signals": GreenhouseServingIcoAiSignals;
   "greenhouse_serving.ico_member_metrics": GreenhouseServingIcoMemberMetrics;


### PR DESCRIPTION
## Summary
- persist ICO/Nexa LLM enrichments into a dedicated serving history table instead of treating current-state rows as the only memory
- read people/space/agency timelines and weekly digests from history with dedupe by `enrichment_id`
- add a historical backfill script and documentation for recovering advisory memory after overwrite runs

## Recovery already executed
- rebuilt monthly ICO snapshots for March 2026 and April 2026
- replayed April LLM enrichments from BigQuery time-travel window into serving history
- reran March and April current-state LLM materialization so current insights and history are both populated again

## Validation
- `pnpm exec vitest run src/lib/ico-engine/ai/llm-enrichment-reader.test.ts src/lib/nexa/digest/build-weekly-digest.test.ts`
- `pnpm exec tsc --noEmit --incremental false`
- `pnpm lint`
- `pnpm build`
- `rg -n "new Pool\(" src --glob '!src/lib/postgres/client.ts'