### PR TITLE
fix: fallback Nexa summaries to history

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - Se agrega `greenhouse_serving.ico_ai_signal_enrichment_history` como archivo append-only de enrichments LLM; `ico_ai_signal_enrichments` se mantiene como snapshot current-state.
 - Los timelines de Agency, Home, Space 360 y Person 360 pasan a leer historial deduplicado por `enrichment_id`, así que una señal que desaparece del mes actual sigue viva en Historial.
 - El weekly digest ahora se arma desde ese historial deduplicado y ya no depende solo del snapshot vigente.
+- Los summary readers de Person 360 y Space 360 ahora hacen fallback al historial recuperado cuando el snapshot current-state del período queda vacío, evitando falsos "Sin datos" en miembros o spaces que sí tuvieron insights días antes.
 - Se agrega replay histórico `historyOnly` con `asOfTime` y script `scripts/backfill-ico-llm-history.ts`; se recuperó el tramo replayable de abril 2026 (`2026-04-15` a `2026-04-17`) y quedó confirmado que `2026-04-01` a `2026-04-10 13:17 UTC` ya no es recuperable vía BigQuery time travel.
 
 ### 2026-04-17 — Nexa Insights: Historial extendido a Home, Space 360 y Person 360

--- a/src/lib/ico-engine/ai/llm-enrichment-reader.test.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-reader.test.ts
@@ -202,6 +202,72 @@ describe('readMemberAiLlmSummary', () => {
       timeline: []
     })
   })
+
+  it('falls back to historical timeline when current-state enrichments are empty', async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          total: 0,
+          succeeded: 0,
+          failed: 0,
+          avg_quality_score: null,
+          last_processed_at: null
+        }
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          run_id: 'EO-AIR-9',
+          status: 'succeeded',
+          started_at: '2026-04-17T09:00:00.000Z',
+          completed_at: '2026-04-17T09:02:00.000Z'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          enrichment_id: 'EO-AIE-90',
+          signal_type: 'root_cause',
+          metric_name: 'ftr_pct',
+          severity: 'critical',
+          explanation_summary: 'Historial recuperado',
+          root_cause_narrative: 'El problema viene de revisión tardía.',
+          recommended_action: 'Revisar con Daniela',
+          processed_at: '2026-04-16T10:20:18.447Z'
+        }
+      ])
+
+    const result = await readMemberAiLlmSummary('member-123', 2026, 4, 3)
+
+    expect(result).toEqual({
+      totalAnalyzed: 1,
+      lastAnalysis: '2026-04-16T10:20:18.447Z',
+      runStatus: 'succeeded',
+      insights: [
+        {
+          id: 'EO-AIE-90',
+          signalType: 'root_cause',
+          metricId: 'ftr_pct',
+          severity: 'critical',
+          explanation: 'Historial recuperado',
+          rootCauseNarrative: 'El problema viene de revisión tardía.',
+          recommendedAction: 'Revisar con Daniela',
+          processedAt: '2026-04-16T10:20:18.447Z'
+        }
+      ],
+      timeline: [
+        {
+          id: 'EO-AIE-90',
+          signalType: 'root_cause',
+          metricId: 'ftr_pct',
+          severity: 'critical',
+          explanation: 'Historial recuperado',
+          rootCauseNarrative: 'El problema viene de revisión tardía.',
+          recommendedAction: 'Revisar con Daniela',
+          processedAt: '2026-04-16T10:20:18.447Z'
+        }
+      ]
+    })
+  })
 })
 
 describe('readSpaceAiLlmSummary', () => {
@@ -283,6 +349,72 @@ describe('readSpaceAiLlmSummary', () => {
         }
       ],
       timeline: []
+    })
+  })
+
+  it('falls back to historical timeline when the current-state space snapshot is empty', async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        {
+          total: 0,
+          succeeded: 0,
+          failed: 0,
+          avg_quality_score: null,
+          last_processed_at: null
+        }
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          run_id: 'EO-AIR-10',
+          status: 'succeeded',
+          started_at: '2026-04-17T10:00:00.000Z',
+          completed_at: '2026-04-17T10:02:00.000Z'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          enrichment_id: 'EO-AIE-91',
+          signal_type: 'recommendation',
+          metric_name: 'otd_pct',
+          severity: 'warning',
+          explanation_summary: 'Historial de espacio recuperado',
+          root_cause_narrative: null,
+          recommended_action: 'Replanificar entregables',
+          processed_at: '2026-04-16T08:45:00.000Z'
+        }
+      ])
+
+    const result = await readSpaceAiLlmSummary('space-123', 2026, 4, 3)
+
+    expect(result).toEqual({
+      totalAnalyzed: 1,
+      lastAnalysis: '2026-04-16T08:45:00.000Z',
+      runStatus: 'succeeded',
+      insights: [
+        {
+          id: 'EO-AIE-91',
+          signalType: 'recommendation',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Historial de espacio recuperado',
+          rootCauseNarrative: null,
+          recommendedAction: 'Replanificar entregables',
+          processedAt: '2026-04-16T08:45:00.000Z'
+        }
+      ],
+      timeline: [
+        {
+          id: 'EO-AIE-91',
+          signalType: 'recommendation',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Historial de espacio recuperado',
+          rootCauseNarrative: null,
+          recommendedAction: 'Replanificar entregables',
+          processedAt: '2026-04-16T08:45:00.000Z'
+        }
+      ]
     })
   })
 })

--- a/src/lib/ico-engine/ai/llm-enrichment-reader.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-reader.ts
@@ -491,13 +491,22 @@ export const readMemberAiLlmSummary = async (
 
   const recentInsights = recentRows.map(mapMemberInsightItem)
 
+  const visibleInsights =
+    recentInsights.length > 0 ? recentInsights : timelineItems.slice(0, Math.max(1, limit))
+
+  const lastAnalysis =
+    recentInsights.length > 0
+      ? toText(totalsRow.last_processed_at)
+      : visibleInsights[0]?.processedAt ?? null
+
   return {
-    totalAnalyzed: recentInsights.length > 0 ? Number(totalsRow.succeeded ?? 0) : 0,
-    lastAnalysis: toText(totalsRow.last_processed_at),
+    totalAnalyzed:
+      recentInsights.length > 0 ? Number(totalsRow.succeeded ?? 0) : timelineItems.length,
+    lastAnalysis,
     runStatus: latestRunRow
       ? (toText(latestRunRow.status) ?? 'failed') as IcoLlmRunStatus
       : null,
-    insights: recentInsights,
+    insights: visibleInsights,
     timeline: timelineItems
   }
 }
@@ -579,13 +588,22 @@ export const readSpaceAiLlmSummary = async (
   const latestRunRow = latestRunRows[0]
   const recentInsights = recentRows.map(mapSpaceInsightItem)
 
+  const visibleInsights =
+    recentInsights.length > 0 ? recentInsights : timelineItems.slice(0, Math.max(1, limit))
+
+  const lastAnalysis =
+    recentInsights.length > 0
+      ? toText(totalsRow.last_processed_at)
+      : visibleInsights[0]?.processedAt ?? null
+
   return {
-    totalAnalyzed: recentInsights.length > 0 ? Number(totalsRow.succeeded ?? 0) : 0,
-    lastAnalysis: toText(totalsRow.last_processed_at),
+    totalAnalyzed:
+      recentInsights.length > 0 ? Number(totalsRow.succeeded ?? 0) : timelineItems.length,
+    lastAnalysis,
     runStatus: latestRunRow
       ? (toText(latestRunRow.status) ?? 'failed') as IcoLlmRunStatus
       : null,
-    insights: recentInsights,
+    insights: visibleInsights,
     timeline: timelineItems
   }
 }


### PR DESCRIPTION
## Summary
- make Person 360 and Space 360 Nexa summary readers fall back to recovered historical insights when the current-state snapshot is empty
- keep timeline payloads intact while preventing false "Sin datos" states for members or spaces that had insights earlier in the month
- add regression tests for member and space summary fallback behavior

## Validation
- `pnpm exec vitest run src/lib/ico-engine/ai/llm-enrichment-reader.test.ts src/lib/nexa/digest/build-weekly-digest.test.ts src/app/api/people/[memberId]/intelligence/route.test.ts`
- `pnpm exec tsc --noEmit --incremental false`
- `pnpm lint`
- `pnpm build`
- local runtime check with Daniela Ferreira now returns `totalAnalyzed: 2` and 2 visible insights from recovered history