### PR TITLE
fix: make Nexa summaries explicit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - Se agrega `greenhouse_serving.ico_ai_signal_enrichment_history` como archivo append-only de enrichments LLM; `ico_ai_signal_enrichments` se mantiene como snapshot current-state.
 - Los timelines de Agency, Home, Space 360 y Person 360 pasan a leer historial deduplicado por `enrichment_id`, así que una señal que desaparece del mes actual sigue viva en Historial.
 - El weekly digest ahora se arma desde ese historial deduplicado y ya no depende solo del snapshot vigente.
-- Los summary readers de Person 360 y Space 360 ahora hacen fallback al historial recuperado cuando el snapshot current-state del período queda vacío, evitando falsos "Sin datos" en miembros o spaces que sí tuvieron insights días antes.
+- Los summary readers de Person 360 y Space 360 ahora exponen contrato explícito `summarySource + activeAnalyzed + historicalAnalyzed + activePreview + historicalPreview`; cuando el período no tiene signals activas, la surface muestra historial recuperado sin depender de un fallback implícito.
 - Se agrega replay histórico `historyOnly` con `asOfTime` y script `scripts/backfill-ico-llm-history.ts`; se recuperó el tramo replayable de abril 2026 (`2026-04-15` a `2026-04-17`) y quedó confirmado que `2026-04-01` a `2026-04-10 13:17 UTC` ya no es recuperable vía BigQuery time travel.
 
 ### 2026-04-17 — Nexa Insights: Historial extendido a Home, Space 360 y Person 360

--- a/docs/architecture/GREENHOUSE_NEXA_INSIGHTS_LAYER_V1.md
+++ b/docs/architecture/GREENHOUSE_NEXA_INSIGHTS_LAYER_V1.md
@@ -5,10 +5,12 @@
 - Runtime activo:
   - Nuevo archivo histórico `greenhouse_serving.ico_ai_signal_enrichment_history` con escritura append-only por run de LLM
   - `ico_ai_signal_enrichments` se mantiene como snapshot current-state del período activo; no cambia el contrato de las surfaces "Recientes"
+  - Los summary readers scoped de Person 360 y Space 360 exponen `summarySource`, `activeAnalyzed`, `historicalAnalyzed`, `activePreview` y `historicalPreview`; el reader decide explícitamente si la surface visible representa estado activo o memoria histórica
   - `readAgencyAiLlmTimeline`, `readMemberAiLlmTimeline` y `readSpaceAiLlmTimeline` ahora leen desde historial, deduplicado por `enrichment_id` con `DISTINCT ON`
   - `src/lib/nexa/digest/build-weekly-digest.ts` ahora arma el corte semanal desde historial deduplicado, no desde el snapshot vigente
 - Contrato operativo:
   - una señal que desaparece del set actual por mejora operativa deja de verse en "Recientes", pero sigue viva en timeline y en el weekly digest de su ventana histórica
+  - las surfaces que muestran summary scoped ya no dependen de un fallback implícito; consumen un payload que declara si la data visible es `active`, `historical` o `empty`
   - reruns del mismo enrichment no duplican timeline/digest: el consumer colapsa a la última versión por `enrichment_id`
   - esto evita pérdida silenciosa de contexto semanal/mensual en People, Space 360, Home y Agency
 

--- a/docs/architecture/Greenhouse_ICO_Engine_v1.md
+++ b/docs/architecture/Greenhouse_ICO_Engine_v1.md
@@ -4,6 +4,7 @@
 
 - Nuevo archivo `greenhouse_serving.ico_ai_signal_enrichment_history` para conservar cada corrida LLM sin sobrescribirla
 - `readAgencyAiLlmTimeline(limit=20)` y los timelines scoped ahora leen desde historial deduplicado por `enrichment_id`, no desde `greenhouse_serving.ico_ai_signal_enrichments`
+- `readMemberAiLlmSummary` y `readSpaceAiLlmSummary` exponen contrato explícito `summarySource + activeAnalyzed + historicalAnalyzed + activePreview + historicalPreview`; la selección de insights visibles deja de depender de fallback implícito
 - `src/lib/nexa/digest/build-weekly-digest.ts` consume el mismo historial deduplicado para no perder advisories cuando cambian las anomalías del período
 - Se agrega replay histórico `historyOnly` con `asOfTime` en `materializeAiLlmEnrichments()` y script operativo `scripts/backfill-ico-llm-history.ts`
 

--- a/src/app/api/people/[memberId]/intelligence/route.test.ts
+++ b/src/app/api/people/[memberId]/intelligence/route.test.ts
@@ -108,6 +108,9 @@ describe('GET /api/people/[memberId]/intelligence', () => {
     })
     mockReadMemberCapacityEconomicsTrend.mockResolvedValue([])
     mockReadMemberAiLlmSummary.mockResolvedValue({
+      summarySource: 'active',
+      activeAnalyzed: 2,
+      historicalAnalyzed: 2,
       totalAnalyzed: 2,
       lastAnalysis: '2026-03-26T02:00:00.000Z',
       runStatus: 'succeeded',
@@ -120,7 +123,28 @@ describe('GET /api/people/[memberId]/intelligence', () => {
           explanation: '@[Space A](space:space-a) está retrasado.',
           recommendedAction: 'Revisar bloqueadores con @[Ana](member:member-2).'
         }
-      ]
+      ],
+      activePreview: [
+        {
+          id: 'EO-AIE-1',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'critical',
+          explanation: '@[Space A](space:space-a) está retrasado.',
+          recommendedAction: 'Revisar bloqueadores con @[Ana](member:member-2).'
+        }
+      ],
+      historicalPreview: [
+        {
+          id: 'EO-AIE-1',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'critical',
+          explanation: '@[Space A](space:space-a) está retrasado.',
+          recommendedAction: 'Revisar bloqueadores con @[Ana](member:member-2).'
+        }
+      ],
+      timeline: []
     })
 
     const response = await GET(
@@ -150,6 +174,9 @@ describe('GET /api/people/[memberId]/intelligence', () => {
     })
     expect(mockReadMemberAiLlmSummary).toHaveBeenCalledWith('member-1', 2026, 4)
     expect(body.nexaInsights).toEqual({
+      summarySource: 'active',
+      activeAnalyzed: 2,
+      historicalAnalyzed: 2,
       totalAnalyzed: 2,
       lastAnalysis: '2026-03-26T02:00:00.000Z',
       runStatus: 'succeeded',
@@ -162,7 +189,28 @@ describe('GET /api/people/[memberId]/intelligence', () => {
           explanation: '@[Space A](space:space-a) está retrasado.',
           recommendedAction: 'Revisar bloqueadores con @[Ana](member:member-2).'
         }
-      ]
+      ],
+      activePreview: [
+        {
+          id: 'EO-AIE-1',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'critical',
+          explanation: '@[Space A](space:space-a) está retrasado.',
+          recommendedAction: 'Revisar bloqueadores con @[Ana](member:member-2).'
+        }
+      ],
+      historicalPreview: [
+        {
+          id: 'EO-AIE-1',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'critical',
+          explanation: '@[Space A](space:space-a) está retrasado.',
+          recommendedAction: 'Revisar bloqueadores con @[Ana](member:member-2).'
+        }
+      ],
+      timeline: []
     })
     expect(body.current.derivedMetrics.find((metric: { metricId: string }) => metric.metricId === 'cost_per_hour')?.value).toBe(13500)
     expect(body.current.derivedMetrics.find((metric: { metricId: string }) => metric.metricId === 'utilization_pct')?.value).toBe(82)

--- a/src/lib/agency/space-360.test.ts
+++ b/src/lib/agency/space-360.test.ts
@@ -317,6 +317,9 @@ describe('getAgencySpace360', () => {
     ])
 
     mockReadSpaceAiLlmSummary.mockResolvedValue({
+      summarySource: 'active',
+      activeAnalyzed: 2,
+      historicalAnalyzed: 2,
       totalAnalyzed: 2,
       lastAnalysis: '2026-03-31T12:10:00.000Z',
       runStatus: 'succeeded',
@@ -329,7 +332,28 @@ describe('getAgencySpace360', () => {
           explanation: 'Space insight',
           recommendedAction: 'Revisar'
         }
-      ]
+      ],
+      activePreview: [
+        {
+          id: 'EO-AIE-30',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Space insight',
+          recommendedAction: 'Revisar'
+        }
+      ],
+      historicalPreview: [
+        {
+          id: 'EO-AIE-30',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Space insight',
+          recommendedAction: 'Revisar'
+        }
+      ],
+      timeline: []
     })
 
     const detail = await getAgencySpace360('space-2')
@@ -337,6 +361,9 @@ describe('getAgencySpace360', () => {
     expect(detail).not.toBeNull()
     expect(detail?.resolutionStatus).toBe('client_and_space')
     expect(detail?.nexaInsights).toEqual({
+      summarySource: 'active',
+      activeAnalyzed: 2,
+      historicalAnalyzed: 2,
       totalAnalyzed: 2,
       lastAnalysis: '2026-03-31T12:10:00.000Z',
       runStatus: 'succeeded',
@@ -349,7 +376,28 @@ describe('getAgencySpace360', () => {
           explanation: 'Space insight',
           recommendedAction: 'Revisar'
         }
-      ]
+      ],
+      activePreview: [
+        {
+          id: 'EO-AIE-30',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Space insight',
+          recommendedAction: 'Revisar'
+        }
+      ],
+      historicalPreview: [
+        {
+          id: 'EO-AIE-30',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Space insight',
+          recommendedAction: 'Revisar'
+        }
+      ],
+      timeline: []
     })
     expect(mockReadSpaceAiLlmSummary).toHaveBeenCalledWith('space-2', 2026, 4)
   })

--- a/src/lib/ico-engine/ai/llm-enrichment-reader.test.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-reader.test.ts
@@ -115,6 +115,12 @@ describe('readMemberAiLlmSummary', () => {
       ])
       .mockResolvedValueOnce([
         {
+          total: 5,
+          last_processed_at: '2026-04-16T10:20:18.447Z'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
           enrichment_id: 'EO-AIE-10',
           signal_type: 'anomaly',
           metric_name: 'otd_pct',
@@ -154,17 +160,22 @@ describe('readMemberAiLlmSummary', () => {
     )
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
+      expect.stringContaining('COUNT(DISTINCT enrichment_id)'),
+      ['member-123']
+    )
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      3,
       expect.stringContaining("AND status = 'succeeded'"),
       ['member-123', 2026, 4, 3]
     )
     expect(mockQuery).toHaveBeenNthCalledWith(
-      3,
+      4,
       expect.stringContaining('FROM greenhouse_serving.ico_ai_enrichment_runs'),
       [2026, 4]
     )
 
-    const memberSql = mockQuery.mock.calls[1][0] as string
-    const memberTimelineSql = mockQuery.mock.calls[3][0] as string
+    const memberSql = mockQuery.mock.calls[2][0] as string
+    const memberTimelineSql = mockQuery.mock.calls[4][0] as string
 
     expect(memberSql).toContain("CASE COALESCE(severity, '')")
     expect(memberSql).toContain("WHEN 'critical' THEN 0")
@@ -174,6 +185,9 @@ describe('readMemberAiLlmSummary', () => {
     expect(memberTimelineSql).toContain('DISTINCT ON (enrichment_id)')
 
     expect(result).toEqual({
+      summarySource: 'active',
+      activeAnalyzed: 2,
+      historicalAnalyzed: 5,
       totalAnalyzed: 2,
       lastAnalysis: '2026-04-15T13:10:00.000Z',
       runStatus: 'partial',
@@ -199,11 +213,34 @@ describe('readMemberAiLlmSummary', () => {
           processedAt: '2026-04-15T12:30:00.000Z'
         }
       ],
+      activePreview: [
+        {
+          id: 'EO-AIE-10',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'critical',
+          explanation: 'Member impact',
+          rootCauseNarrative: null,
+          recommendedAction: 'Actuar',
+          processedAt: '2026-04-15T13:10:00.000Z'
+        },
+        {
+          id: 'EO-AIE-11',
+          signalType: 'recommendation',
+          metricId: 'rpa_avg',
+          severity: 'warning',
+          explanation: 'Otra señal',
+          rootCauseNarrative: null,
+          recommendedAction: null,
+          processedAt: '2026-04-15T12:30:00.000Z'
+        }
+      ],
+      historicalPreview: [],
       timeline: []
     })
   })
 
-  it('falls back to historical timeline when current-state enrichments are empty', async () => {
+  it('surfaces historical insights explicitly when there are no active enrichments for the period', async () => {
     mockQuery
       .mockResolvedValueOnce([
         {
@@ -212,6 +249,12 @@ describe('readMemberAiLlmSummary', () => {
           failed: 0,
           avg_quality_score: null,
           last_processed_at: null
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          total: 1,
+          last_processed_at: '2026-04-16T10:20:18.447Z'
         }
       ])
       .mockResolvedValueOnce([])
@@ -239,10 +282,26 @@ describe('readMemberAiLlmSummary', () => {
     const result = await readMemberAiLlmSummary('member-123', 2026, 4, 3)
 
     expect(result).toEqual({
+      summarySource: 'historical',
+      activeAnalyzed: 0,
+      historicalAnalyzed: 1,
       totalAnalyzed: 1,
       lastAnalysis: '2026-04-16T10:20:18.447Z',
       runStatus: 'succeeded',
       insights: [
+        {
+          id: 'EO-AIE-90',
+          signalType: 'root_cause',
+          metricId: 'ftr_pct',
+          severity: 'critical',
+          explanation: 'Historial recuperado',
+          rootCauseNarrative: 'El problema viene de revisión tardía.',
+          recommendedAction: 'Revisar con Daniela',
+          processedAt: '2026-04-16T10:20:18.447Z'
+        }
+      ],
+      activePreview: [],
+      historicalPreview: [
         {
           id: 'EO-AIE-90',
           signalType: 'root_cause',
@@ -284,6 +343,12 @@ describe('readSpaceAiLlmSummary', () => {
       ])
       .mockResolvedValueOnce([
         {
+          total: 4,
+          last_processed_at: '2026-04-16T08:45:00.000Z'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
           enrichment_id: 'EO-AIE-20',
           signal_type: 'anomaly',
           metric_name: 'otd_pct',
@@ -313,17 +378,22 @@ describe('readSpaceAiLlmSummary', () => {
     )
     expect(mockQuery).toHaveBeenNthCalledWith(
       2,
+      expect.stringContaining('COUNT(DISTINCT enrichment_id)'),
+      ['space-123']
+    )
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      3,
       expect.stringContaining("AND status = 'succeeded'"),
       ['space-123', 2026, 4, 3]
     )
     expect(mockQuery).toHaveBeenNthCalledWith(
-      3,
+      4,
       expect.stringContaining('WHERE space_id = $1'),
       ['space-123', 2026, 4]
     )
 
-    const spaceSql = mockQuery.mock.calls[1][0] as string
-    const spaceTimelineSql = mockQuery.mock.calls[3][0] as string
+    const spaceSql = mockQuery.mock.calls[2][0] as string
+    const spaceTimelineSql = mockQuery.mock.calls[4][0] as string
 
     expect(spaceSql).toContain("CASE COALESCE(severity, '')")
     expect(spaceSql).toContain("WHEN 'critical' THEN 0")
@@ -333,6 +403,9 @@ describe('readSpaceAiLlmSummary', () => {
     expect(spaceTimelineSql).toContain('DISTINCT ON (enrichment_id)')
 
     expect(result).toEqual({
+      summarySource: 'active',
+      activeAnalyzed: 2,
+      historicalAnalyzed: 4,
       totalAnalyzed: 2,
       lastAnalysis: '2026-04-15T14:00:00.000Z',
       runStatus: 'succeeded',
@@ -348,11 +421,24 @@ describe('readSpaceAiLlmSummary', () => {
           processedAt: '2026-04-15T14:00:00.000Z'
         }
       ],
+      activePreview: [
+        {
+          id: 'EO-AIE-20',
+          signalType: 'anomaly',
+          metricId: 'otd_pct',
+          severity: 'critical',
+          explanation: 'Space impact',
+          rootCauseNarrative: null,
+          recommendedAction: 'Escalar',
+          processedAt: '2026-04-15T14:00:00.000Z'
+        }
+      ],
+      historicalPreview: [],
       timeline: []
     })
   })
 
-  it('falls back to historical timeline when the current-state space snapshot is empty', async () => {
+  it('surfaces historical space insights explicitly when the active snapshot is empty', async () => {
     mockQuery
       .mockResolvedValueOnce([
         {
@@ -361,6 +447,12 @@ describe('readSpaceAiLlmSummary', () => {
           failed: 0,
           avg_quality_score: null,
           last_processed_at: null
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          total: 1,
+          last_processed_at: '2026-04-16T08:45:00.000Z'
         }
       ])
       .mockResolvedValueOnce([])
@@ -388,10 +480,26 @@ describe('readSpaceAiLlmSummary', () => {
     const result = await readSpaceAiLlmSummary('space-123', 2026, 4, 3)
 
     expect(result).toEqual({
+      summarySource: 'historical',
+      activeAnalyzed: 0,
+      historicalAnalyzed: 1,
       totalAnalyzed: 1,
       lastAnalysis: '2026-04-16T08:45:00.000Z',
       runStatus: 'succeeded',
       insights: [
+        {
+          id: 'EO-AIE-91',
+          signalType: 'recommendation',
+          metricId: 'otd_pct',
+          severity: 'warning',
+          explanation: 'Historial de espacio recuperado',
+          rootCauseNarrative: null,
+          recommendedAction: 'Replanificar entregables',
+          processedAt: '2026-04-16T08:45:00.000Z'
+        }
+      ],
+      activePreview: [],
+      historicalPreview: [
         {
           id: 'EO-AIE-91',
           signalType: 'recommendation',

--- a/src/lib/ico-engine/ai/llm-enrichment-reader.ts
+++ b/src/lib/ico-engine/ai/llm-enrichment-reader.ts
@@ -15,6 +15,10 @@ import type {
 } from './llm-types'
 
 type RawRow = Record<string, unknown>
+type HistoricalTotalsRow = {
+  total: unknown
+  last_processed_at: unknown
+}
 
 const toNumber = (value: unknown) => {
   if (typeof value === 'number') return Number.isFinite(value) ? value : null
@@ -129,6 +133,56 @@ const buildHistoricalTimelineQuery = (scopeSql: string) => `
   ORDER BY processed_at DESC
   LIMIT $2
 `
+
+const buildHistoricalTotalsQuery = (scopeSql: string) => `
+  SELECT
+    COUNT(DISTINCT enrichment_id) AS total,
+    MAX(processed_at)::text AS last_processed_at
+  FROM ${ENRICHMENT_HISTORY_TABLE}
+  WHERE ${scopeSql}
+    AND status = 'succeeded'
+`
+
+const buildScopedSummarySelection = <T extends { processedAt: string }>(
+  activeTotalsRow: RawRow,
+  historicalTotalsRow: HistoricalTotalsRow,
+  activePreview: T[],
+  historicalPreview: T[]
+) => {
+  const activeAnalyzed = Number(activeTotalsRow.succeeded ?? 0)
+  const historicalAnalyzed = toNumber(historicalTotalsRow.total) ?? 0
+
+  const summarySource =
+    activeAnalyzed > 0 ? 'active' : historicalAnalyzed > 0 ? 'historical' : 'empty'
+
+  const totalAnalyzed =
+    summarySource === 'active' ? activeAnalyzed : summarySource === 'historical' ? historicalAnalyzed : 0
+
+  const lastAnalysis =
+    summarySource === 'active'
+      ? toText(activeTotalsRow.last_processed_at)
+      : summarySource === 'historical'
+        ? toText(historicalTotalsRow.last_processed_at)
+        : null
+
+  const insights =
+    summarySource === 'active'
+      ? activePreview
+      : summarySource === 'historical'
+        ? historicalPreview
+        : []
+
+  return {
+    summarySource,
+    activeAnalyzed,
+    historicalAnalyzed,
+    totalAnalyzed,
+    lastAnalysis,
+    insights,
+    activePreview,
+    historicalPreview
+  } as const
+}
 
 export const readAgencyAiLlmTimeline = async (
   limit = TIMELINE_DEFAULT_LIMIT
@@ -420,7 +474,7 @@ export const readMemberAiLlmSummary = async (
   periodMonth: number,
   limit = 3
 ): Promise<MemberNexaInsightsPayload> => {
-  const [totalsRows, recentRows, latestRunRows, timelineItems] = await Promise.all([
+  const [totalsRows, historicalTotalsRows, recentRows, latestRunRows, timelineItems] = await Promise.all([
     query<RawRow>(
       `
         SELECT
@@ -435,6 +489,10 @@ export const readMemberAiLlmSummary = async (
           AND period_month = $3
       `,
       [memberId, periodYear, periodMonth]
+    ).catch(() => []),
+    query<HistoricalTotalsRow>(
+      buildHistoricalTotalsQuery('member_id = $1'),
+      [memberId]
     ).catch(() => []),
     query<RawRow>(
       `
@@ -487,26 +545,31 @@ export const readMemberAiLlmSummary = async (
   ])
 
   const totalsRow = totalsRows[0] ?? {}
+  const historicalTotalsRow = historicalTotalsRows[0] ?? { total: 0, last_processed_at: null }
   const latestRunRow = latestRunRows[0]
 
-  const recentInsights = recentRows.map(mapMemberInsightItem)
+  const activePreview = recentRows.map(mapMemberInsightItem)
+  const historicalPreview = timelineItems.slice(0, Math.max(1, limit))
 
-  const visibleInsights =
-    recentInsights.length > 0 ? recentInsights : timelineItems.slice(0, Math.max(1, limit))
-
-  const lastAnalysis =
-    recentInsights.length > 0
-      ? toText(totalsRow.last_processed_at)
-      : visibleInsights[0]?.processedAt ?? null
+  const scopedSummary = buildScopedSummarySelection(
+    totalsRow,
+    historicalTotalsRow,
+    activePreview,
+    historicalPreview
+  )
 
   return {
-    totalAnalyzed:
-      recentInsights.length > 0 ? Number(totalsRow.succeeded ?? 0) : timelineItems.length,
-    lastAnalysis,
+    summarySource: scopedSummary.summarySource,
+    activeAnalyzed: scopedSummary.activeAnalyzed,
+    historicalAnalyzed: scopedSummary.historicalAnalyzed,
+    totalAnalyzed: scopedSummary.totalAnalyzed,
+    lastAnalysis: scopedSummary.lastAnalysis,
     runStatus: latestRunRow
       ? (toText(latestRunRow.status) ?? 'failed') as IcoLlmRunStatus
       : null,
-    insights: visibleInsights,
+    insights: scopedSummary.insights,
+    activePreview: scopedSummary.activePreview,
+    historicalPreview: scopedSummary.historicalPreview,
     timeline: timelineItems
   }
 }
@@ -517,7 +580,7 @@ export const readSpaceAiLlmSummary = async (
   periodMonth: number,
   limit = 3
 ): Promise<SpaceNexaInsightsPayload> => {
-  const [totalsRows, recentRows, latestRunRows, timelineItems] = await Promise.all([
+  const [totalsRows, historicalTotalsRows, recentRows, latestRunRows, timelineItems] = await Promise.all([
     query<RawRow>(
       `
         SELECT
@@ -532,6 +595,10 @@ export const readSpaceAiLlmSummary = async (
           AND period_month = $3
       `,
       [spaceId, periodYear, periodMonth]
+    ).catch(() => []),
+    query<HistoricalTotalsRow>(
+      buildHistoricalTotalsQuery('space_id = $1'),
+      [spaceId]
     ).catch(() => []),
     query<RawRow>(
       `
@@ -585,25 +652,31 @@ export const readSpaceAiLlmSummary = async (
   ])
 
   const totalsRow = totalsRows[0] ?? {}
+  const historicalTotalsRow = historicalTotalsRows[0] ?? { total: 0, last_processed_at: null }
   const latestRunRow = latestRunRows[0]
-  const recentInsights = recentRows.map(mapSpaceInsightItem)
 
-  const visibleInsights =
-    recentInsights.length > 0 ? recentInsights : timelineItems.slice(0, Math.max(1, limit))
+  const activePreview = recentRows.map(mapSpaceInsightItem)
+  const historicalPreview = timelineItems.slice(0, Math.max(1, limit))
 
-  const lastAnalysis =
-    recentInsights.length > 0
-      ? toText(totalsRow.last_processed_at)
-      : visibleInsights[0]?.processedAt ?? null
+  const scopedSummary = buildScopedSummarySelection(
+    totalsRow,
+    historicalTotalsRow,
+    activePreview,
+    historicalPreview
+  )
 
   return {
-    totalAnalyzed:
-      recentInsights.length > 0 ? Number(totalsRow.succeeded ?? 0) : timelineItems.length,
-    lastAnalysis,
+    summarySource: scopedSummary.summarySource,
+    activeAnalyzed: scopedSummary.activeAnalyzed,
+    historicalAnalyzed: scopedSummary.historicalAnalyzed,
+    totalAnalyzed: scopedSummary.totalAnalyzed,
+    lastAnalysis: scopedSummary.lastAnalysis,
     runStatus: latestRunRow
       ? (toText(latestRunRow.status) ?? 'failed') as IcoLlmRunStatus
       : null,
-    insights: visibleInsights,
+    insights: scopedSummary.insights,
+    activePreview: scopedSummary.activePreview,
+    historicalPreview: scopedSummary.historicalPreview,
     timeline: timelineItems
   }
 }

--- a/src/lib/ico-engine/ai/llm-types.ts
+++ b/src/lib/ico-engine/ai/llm-types.ts
@@ -149,11 +149,18 @@ export interface MemberNexaInsightItem {
   processedAt: string
 }
 
+export type NexaSummarySource = 'active' | 'historical' | 'empty'
+
 export interface MemberNexaInsightsPayload {
+  summarySource: NexaSummarySource
+  activeAnalyzed: number
+  historicalAnalyzed: number
   totalAnalyzed: number
   lastAnalysis: string | null
   runStatus: IcoLlmRunStatus | null
   insights: MemberNexaInsightItem[]
+  activePreview: MemberNexaInsightItem[]
+  historicalPreview: MemberNexaInsightItem[]
   timeline: MemberNexaInsightItem[]
 }
 
@@ -169,10 +176,15 @@ export interface SpaceNexaInsightItem {
 }
 
 export interface SpaceNexaInsightsPayload {
+  summarySource: NexaSummarySource
+  activeAnalyzed: number
+  historicalAnalyzed: number
   totalAnalyzed: number
   lastAnalysis: string | null
   runStatus: IcoLlmRunStatus | null
   insights: SpaceNexaInsightItem[]
+  activePreview: SpaceNexaInsightItem[]
+  historicalPreview: SpaceNexaInsightItem[]
   timeline: SpaceNexaInsightItem[]
 }
 

--- a/src/views/greenhouse/agency/space-360/Space360View.test.tsx
+++ b/src/views/greenhouse/agency/space-360/Space360View.test.tsx
@@ -117,10 +117,37 @@ const detail: Space360Detail = {
     ]
   },
   nexaInsights: {
+    summarySource: 'active',
+    activeAnalyzed: 3,
+    historicalAnalyzed: 3,
     totalAnalyzed: 3,
     lastAnalysis: '2026-04-15T16:00:00.000Z',
     runStatus: 'succeeded',
     insights: [
+      {
+        id: 'space-insight-1',
+        signalType: 'delivery',
+        metricId: 'otd_pct',
+        severity: 'warning',
+        explanation: 'La OTD del Space cayó en el último corte y conviene revisar el backlog activo.',
+        rootCauseNarrative: null,
+        recommendedAction: 'Coordina con el equipo para limpiar el backlog y monitorea el próximo cierre.',
+        processedAt: '2026-04-15T16:00:00.000Z'
+      }
+    ],
+    activePreview: [
+      {
+        id: 'space-insight-1',
+        signalType: 'delivery',
+        metricId: 'otd_pct',
+        severity: 'warning',
+        explanation: 'La OTD del Space cayó en el último corte y conviene revisar el backlog activo.',
+        rootCauseNarrative: null,
+        recommendedAction: 'Coordina con el equipo para limpiar el backlog y monitorea el próximo cierre.',
+        processedAt: '2026-04-15T16:00:00.000Z'
+      }
+    ],
+    historicalPreview: [
       {
         id: 'space-insight-1',
         signalType: 'delivery',

--- a/src/views/greenhouse/people/tabs/PersonActivityTab.tsx
+++ b/src/views/greenhouse/people/tabs/PersonActivityTab.tsx
@@ -72,10 +72,15 @@ const shouldShowPendingClosures = (snapshot: IcoMetricSnapshot | null) =>
   Boolean(snapshot && snapshot.context.totalTasks > 0 && snapshot.context.completedTasks === 0)
 
 const EMPTY_NEXA_INSIGHTS: MemberNexaInsightsPayload = {
+  summarySource: 'empty',
+  activeAnalyzed: 0,
+  historicalAnalyzed: 0,
   totalAnalyzed: 0,
   lastAnalysis: null,
   runStatus: null,
   insights: [],
+  activePreview: [],
+  historicalPreview: [],
   timeline: []
 }
 


### PR DESCRIPTION
## Summary
- replace implicit summary fallback logic with an explicit scoped summary contract for Nexa member and space readers
- expose `summarySource`, `activeAnalyzed`, `historicalAnalyzed`, `activePreview`, and `historicalPreview` while keeping `insights` as the visible preview for backward compatibility
- document the contract so current-state vs historical memory stays explicit across serving and UI consumers

## Validation
- `pnpm exec vitest run src/lib/ico-engine/ai/llm-enrichment-reader.test.ts src/app/api/people/[memberId]/intelligence/route.test.ts src/lib/agency/space-360.test.ts src/views/greenhouse/agency/space-360/Space360View.test.tsx`
- `pnpm exec tsc --noEmit --incremental false`
- `pnpm lint`
- `pnpm build`