### PR TITLE
feat(task-464e): pricing builder backend + primitives (Ola 4 phase 1)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -101,6 +101,7 @@ Esto viola el multi-agent operating model (`docs/operations/MULTI_AGENT_WORKTREE
 4. `git stash` o `git restore` los archivos del primary worktree después de mover
 
 Dejé los archivos tal cual están (no los toqué ni los incluí en mis commits) para que Codex pueda recuperarlos intactos. Mi rama `task/TASK-464e-standalone-components` NO incluye nada de ese WIP.
+
 ## Sesion 2026-04-18 — TASK-464d Pricing Engine Full-Model Refactor (cierre)
 
 - **Owner:** Codex

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -25,6 +25,7 @@ Documentacion oficial de la plataforma Greenhouse. Cada documento describe como 
 
 - [Cotizaciones multi-source](finance/cotizaciones-multi-source.md) — cotizaciones de Nubox y HubSpot unificadas, sync automatico, creacion outbound, mapeo de estados
 - [Cotizaciones — Gobernanza, versiones, aprobaciones y templates](finance/cotizaciones-gobernanza.md) — runtime de gobernanza interna: versiones con diff, approval por excepción conectado al margin health, terms library con variables, templates reutilizables y audit inmutable
+- [Pricing Comercial — Catálogo, Motor y Builder de Cotizaciones](finance/pricing-comercial.md) — **programa en diseño** (TASK-463..468): catálogo canónico de roles/tools/overhead/services, engine v2 multi-moneda con tier compliance, builder con cost stack gated, admin self-service y aislamiento payroll
 - [HES — Recepción y validación de servicio](finance/hes-recepcion-y-validacion.md) — hoja de entrada de servicio como respaldo recibido del cliente, estados visibles y herencia documental desde la OC
 - [Modulos de Caja — Cobros, Pagos, Banco, Cuenta Accionista y Posicion de Caja](finance/modulos-caja-cobros-pagos.md) — cobros (cash in), pagos (cash out), tesoreria por instrumento, cuenta corriente accionista y diferencia devengado vs caja
 

--- a/docs/documentation/finance/pricing-comercial.md
+++ b/docs/documentation/finance/pricing-comercial.md
@@ -1,0 +1,156 @@
+# Pricing Comercial — Catálogo, Motor y Builder de Cotizaciones
+
+> **Tipo de documento:** Documentacion funcional (lenguaje simple)
+> **Version:** 1.0
+> **Creado:** 2026-04-18 por Claude (TASK-469)
+> **Ultima actualizacion:** 2026-04-18 por Claude (TASK-469)
+> **Estado:** Programa en diseño (TASK-463..468 en backlog; no implementado en runtime todavía)
+> **Documentacion tecnica:**
+> - Plano UI: [TASK-469 — Commercial Pricing UI Interface Plan](../../tasks/complete/TASK-469-commercial-pricing-ui-interface-plan.md)
+> - Tasks de schema + engine: [TASK-464a..d](../../tasks/to-do/) — roles, governance, tool catalog, engine
+> - Task bridge payroll: [TASK-468](../../tasks/to-do/TASK-468-payroll-commercial-employment-types-unification.md)
+
+## Que es
+
+El programa de pricing comercial es el sistema que Efeonce usa internamente para cotizar a un cliente de forma consistente, auditable y alineada con el margen objetivo de la agencia. Es la combinación de tres cosas: un **catálogo canónico** de lo que Efeonce vende (roles, herramientas, overhead, servicios empaquetados), un **motor de pricing** que aplica las reglas comerciales (modelo, país, moneda, tier), y un **builder de cotizaciones** que los Account Leads usan día a día.
+
+El programa nace de un problema real: hoy cada Account Lead cotiza copiando Excels viejos, interpreta márgenes con criterio propio y Efeonce no tiene forma rápida de saber si una cotización tiene el margen que corresponde según el tier de rol y el modelo comercial. El programa elimina esa improvisación sin volverse burocrático: los defaults están bien pensados, el override existe cuando hace sentido, y Finance gana visibilidad sin pedirle permiso al Account Lead.
+
+## Que resuelve
+
+| Dolor operativo | Como lo resuelve el programa |
+|---|---|
+| Cada cotización se arma desde cero copiando Excels viejos | Catálogo canónico de 33 roles, 26 herramientas, 9 overhead add-ons y servicios empaquetados — todo con SKU estable |
+| El margen no se ve hasta que Finance lo calcula ex-post | Cost stack panel en el builder muestra margen bruto en vivo (gated a finance/admin — el Account Lead no lo ve por default) |
+| No hay una sola tarifa — cambia por empleo, país, moneda, modelo | Pricing engine v2 aplica employment_type × country_factor × commercial_model × currency en un solo paso determinista |
+| Cotizar para Pinturas Berel en MXN obliga a conversiones manuales | Multi-currency output con exchange rate snapshot inmutable al momento de envío |
+| Revisar qué se le cotizó al cliente hace 6 meses es forense de Excel | Cada quote tiene su versión, su sales context snapshot y su audit trail de cambios |
+| Agregar un rol nuevo o una herramienta nueva requiere un developer | Admin UI self-service `/admin/pricing-catalog` con CRUD completo y audit log |
+
+## Pilares
+
+### 1. Catálogo canónico (lo que Efeonce vende)
+
+Cuatro tipos de ítems vendibles conviven en el catálogo:
+
+- **Roles vendibles** (33, SKU `ECG-001..033`): Sr Strategist, Mid Designer, Jr Developer, etc. Cada rol tiene una tarifa base por employment_type y moneda, y pertenece a un tier (Commoditizado, Especializado, Estratégico, IP Propietaria) que define el rango de margen objetivo.
+- **Herramientas** (26, SKU externo del proveedor): Figma, Notion, Adobe Creative Cloud, Envato, etc. Cada una tiene un modelo de tarifa (per-seat, flat mensual, prorrateo por proyecto) y metadata de proveedor.
+- **Overhead add-ons** (9): PM Fee, Setup Staff Augmentation, Transactional Fee, AI Infra, Efeonce Operational, Descuento por Retención. Se aplican como porcentaje sobre subtotal o monto fijo, con fórmulas parseables (`10% del subtotal`, `1 mes del costo del recurso`, `4-7% variable`).
+- **Servicios empaquetados** (7 activos + 41 placeholder, SKU `EFG-001..048`): combinaciones recurrentes de roles + herramientas + overhead con una composición fija (ej. "Branding Básico" = Sr Strategist 0.25 FTE + Mid Designer 0.5 FTE + PM Fee 5%).
+
+> Detalle técnico: schemas `greenhouse_commercial.sellable_roles`, `tool_catalog` (extendido), `overhead_addons`, `service_catalog`. Ver [TASK-464a](../../tasks/to-do/TASK-464a-sellable-roles-catalog-canonical.md), [TASK-464c](../../tasks/to-do/TASK-464c-tool-catalog-extension-overhead-addons.md), [TASK-465](../../tasks/to-do/TASK-465-service-composition-catalog-ui.md).
+
+### 2. Governance (las reglas del comercio)
+
+Además del catálogo, hay tablas que fijan las **dimensiones comerciales**:
+
+- **Tiers de rol** (4): Commoditizado, Especializado, Estratégico, IP Propietaria — cada uno con margen min / opt / max (ej. Estratégico: 30-40%)
+- **Modelos comerciales** (4): On-Going (retainer), On-Demand (+10% sobre tarifa base), Hybrid (+5%), License / Consulting (+15%)
+- **Factores por país** (6): Chile Corporate (1.0), Chile PYME (0.9), Colombia / LATAM (0.85-0.9), International USD (1.0), Licitación Pública (1.2), Cliente Estratégico (descuento negociado)
+- **Tipos de contratación** (6): Indefinido CLP, Plazo Fijo CLP, Honorarios CLP, Contractor Deel USD, Contractor EOR USD, Part-time CLP — cada uno con su propia composición de costo previsional + fee de gestión
+- **FTE hours guide**: equivalencia `% dedicación → horas mensuales` (0.1 FTE = 17h, 0.25 FTE = 42h, 1.0 FTE = 168h)
+
+Estas dimensiones son code-versioned (vocabulario cerrado, no aprendido del CSV). Cambiarlas requiere migración + deploy — no se improvisan desde admin UI.
+
+> Detalle técnico: schemas `greenhouse_commercial.role_tier_margins`, `commercial_model_multipliers`, `country_pricing_factors`, `employment_types`, `fte_hours_guide`. Ver [TASK-464b](../../tasks/to-do/TASK-464b-pricing-governance-tables.md).
+
+### 3. Motor de pricing (el cerebro)
+
+El engine v2 toma una cotización en estado bruto (cliente, modelo, país, moneda, líneas) y devuelve:
+
+1. **Cost stack por línea**: costo base + bonos + previsional + fee de gestión (deel/EOR) — gated a finance/admin
+2. **Precio al cliente por línea**: costo × (1 + margen_tier) × multiplicador_modelo × factor_país
+3. **Totales multi-moneda**: el mismo quote renderizable en CLP, USD, EUR, GBP con snapshot de exchange rate
+4. **Tier compliance flag**: la cotización está `below_min` / `in_range` / `above_max` vs el tier objetivo
+5. **Auto-resolve de addons**: si aplica PM Fee, Setup Aug, etc. según la composición de la quote
+
+El engine consume tablas ya normalizadas; no parsea CSV en runtime. Si una línea hace referencia a un SKU inexistente, falla de forma determinista — no adivina.
+
+> Detalle técnico: `src/lib/commercial/pricing-engine-v2.ts` (consume tablas de TASK-464a/b/c, adapta backward-compat vía `costing-engine.ts` legacy). Ver [TASK-464d](../../tasks/to-do/TASK-464d-pricing-engine-full-model-refactor.md).
+
+### 4. Builder de cotizaciones (la experiencia)
+
+El builder (superficie visible que ve el Account Lead) tiene tres zonas:
+
+- **Card principal**: header con logo + número + fechas + cliente/deal, line items editables con 4 tipos de picker (rol, herramienta, overhead, servicio), totales al pie
+- **Sidebar contextual**: modelo comercial, país, moneda, tipo de contratación, términos de pago, CTAs "Guardar borrador" / "Enviar al cliente" / "Vista previa"
+- **Cost stack panel** (gated a finance/admin): desglose de costo, margen bruto con semáforo, tier fit indicador
+
+El semáforo de margen usa cuatro estados con icono + label + color (nunca solo color):
+
+| Estado | Rango vs tier objetivo | Icono | Label |
+|---|---|---|---|
+| Crítico | marginPct < tier.min | `tabler-alert-triangle` | Crítico |
+| Atención | tier.min ≤ marginPct < tier.opt | `tabler-alert-circle` | Atención |
+| Óptimo | tier.opt ≤ marginPct ≤ tier.max | `tabler-circle-check` | Óptimo |
+| Sobre meta | marginPct > tier.max | `tabler-info-circle` | Sobre meta |
+
+"Sobre meta" no es malo — puede indicar una cotización muy competitiva con margen de sobra; el semáforo solo comunica "estás fuera del rango objetivo por arriba" para que Finance sepa si hay espacio para negociar o si es un error de captura.
+
+> Detalle técnico: componentes en `src/components/greenhouse/pricing/` (9 piezas nuevas inventariadas en TASK-469 §3), views en `src/views/greenhouse/finance/quotes/`. Ver [TASK-464e](../../tasks/to-do/TASK-464e-quote-builder-ui-exposure.md), [TASK-465](../../tasks/to-do/TASK-465-service-composition-catalog-ui.md), [TASK-466](../../tasks/to-do/TASK-466-multi-currency-quote-output.md).
+
+### 5. Admin UI self-service (Torre de Control)
+
+`/admin/pricing-catalog` permite que Finance y admins de Efeonce evolucionen el catálogo sin developer:
+
+- CRUD sobre roles, herramientas, overhead add-ons, servicios empaquetados
+- Lectura sobre tiers, modelos comerciales, factores de país, tipos de contratación (edición de estos requiere migración — son code-versioned)
+- Audit timeline que muestra quién cambió qué precio, cuándo, y con qué razón
+- Preview de rates vigentes de payroll (AFP, previsional) como referencia read-only para que se entienda por qué un tipo de contratación cuesta lo que cuesta
+
+> Detalle técnico: `src/views/greenhouse/admin/pricing-catalog/`. Ver [TASK-467](../../tasks/to-do/TASK-467-pricing-catalog-admin-ui.md).
+
+## Relación con otros módulos
+
+### Con HubSpot
+
+Crear una cotización en Greenhouse desde `/finance/cotizaciones` propaga automáticamente a HubSpot (nombre, total, estado, deal asociado). Ediciones significativas (send, approve, nueva versión) también sincronizan. La cotización canónica vive en Greenhouse; HubSpot es el espejo donde el equipo comercial trabaja su pipeline.
+
+> Detalle técnico: [TASK-463](../../tasks/to-do/TASK-463-unified-quote-builder-hubspot-bidirectional.md).
+
+### Con Payroll
+
+El programa comercial **no modifica payroll**. Cuando el builder necesita saber cuánto cuesta un "Indefinido CLP" en términos de AFP + previsional + ISAPRE, lee directamente de `greenhouse_payroll.chile_afp_rates`, `chile_previred_indicators` y `chile_tax_brackets` — SELECT-only, sin triggers, sin FK sobre payroll. El programa tiene su propio catálogo `greenhouse_commercial.employment_types` que resuelve alias desde strings legacy de payroll vía un resolver commercial-side.
+
+Esto preserva el baseline de regresión payroll (194 tests / 29 files) sin excepciones.
+
+> Detalle técnico: [TASK-468](../../tasks/to-do/TASK-468-payroll-commercial-employment-types-unification.md).
+
+### Con Finance (P&L, margen)
+
+Una vez la cotización está **aprobada y convertida en contrato**, entra al flujo tradicional de Finance: se materializa como income esperado, se asignan costos reales (payroll de los colaboradores asignados + herramientas + overhead consumido), y el P&L muestra margen real vs proyectado. El pricing engine proyecta; el P&L mide. Si el margen real del servicio difiere del proyectado >10%, el Finance Signal Engine lo levanta como anomalía.
+
+> Detalle técnico: [GREENHOUSE_FINANCE_ARCHITECTURE_V1.md](../../architecture/GREENHOUSE_FINANCE_ARCHITECTURE_V1.md), [TASK-245](../../tasks/complete/TASK-245-finance-signal-engine.md).
+
+### Con Business Lines
+
+Cada servicio empaquetado y cada herramienta declaran `applicable_business_lines` (globe, wave, reach, efeonce_digital, crm_solutions). Esto permite que el reporte de MRR y margen por BU sea exacto — no se mezclan servicios de Globe con capacity de Reach.
+
+> Detalle técnico: [GREENHOUSE_BUSINESS_LINES_ARCHITECTURE_V1.md](../../architecture/GREENHOUSE_BUSINESS_LINES_ARCHITECTURE_V1.md).
+
+## Aislamiento de payroll (regla dura)
+
+Ningún componente del programa comercial toca archivos dentro de `src/views/greenhouse/hr/payroll/**` ni `src/components/hr/payroll/**`. Los 194 tests de payroll (29 archivos) son gate de regresión antes de cualquier merge del programa. El employment_type canónico vive en commercial; la facticidad del contract_type por colaborador sigue viviendo en payroll.
+
+## Orden de implementación (6 olas)
+
+El programa se implementa en olas para no romper flujos vivos:
+
+1. **Ola 1** — TASK-458 fix de labels en `/finance/pipeline` (ya completado)
+2. **Ola 2** — schema + seeds: TASK-464a (roles), TASK-468 (bridge payroll), TASK-464b (governance), TASK-464c (tools + overhead), TASK-464d (engine v2)
+3. **Ola 3** — copy canónico + scaffolds UI: TASK-469 Slice 4 (ya completado)
+4. **Ola 4** — UI builder + admin: TASK-464e (quote builder pickers + cost stack), TASK-465 (service composition), TASK-467 (admin UI)
+5. **Ola 5** — integración externa: TASK-463 (HubSpot bidirectional), TASK-466 (multi-currency PDF + email)
+6. **Ola 6** — revenue pipeline hybrid: TASK-453..457 + TASK-460..462 (contract/SOW/MSA, MRR/ARR, pipeline UI)
+
+Durante Ola 2-3 el portal sigue usando el engine v1 y el flow de cotización legacy. La migración al engine v2 + UI nueva ocurre en Ola 4 con feature flag; el legacy queda deprecado en Ola 5.
+
+## Componentes UI disponibles (pre-Ola 4)
+
+Tres primitives presentacionales standalone ya están implementados en `src/components/greenhouse/pricing/` y pueden ser consumidos por features que no dependen del engine v2:
+
+- **`MarginIndicatorBadge`** — semáforo de margen con los 4 estados del tier fit; recibe `marginPct` y `target {min, opt, max}` ya calculados por el caller.
+- **`CurrencySwitcher`** — selector de 4 monedas (CLP, USD, EUR, GBP) con disclaimer opcional de exchange rate snapshot.
+- **`PricingCatalogNavCard`** — card de navegación a secciones del admin catalog (roles, tools, overhead, etc.) con icon + count + link.
+
+El resto (CostStackPanel, SellableItemPickerDrawer, ServiceCompositionEditor, QuickEntityFormDrawer, PriceChangeAuditTimeline, SellableItemRow) requiere el engine v2 y catálogos de Ola 2, por lo que llegan con TASK-464e/465/467.

--- a/docs/tasks/in-progress/TASK-464e-quote-builder-ui-exposure.md
+++ b/docs/tasks/in-progress/TASK-464e-quote-builder-ui-exposure.md
@@ -1,12 +1,22 @@
 # TASK-464e — Quote Builder UI Exposure (Role/Tool/Addon Pickers + Cost Stack Gated)
 
+## Delta 2026-04-18
+
+Reconciliación vs TASK-469 (plano maestro, posterior a esta spec) + realidad del repo:
+
+- **Pickers**: la spec original listó 4 autocompletes separados en `workspace/`. TASK-469 §B canoniza **un solo drawer con 4 tabs** en `src/components/greenhouse/pricing/SellableItemPickerDrawer.tsx` (reusable por TASK-465/467). Adopto la versión del plano — los 4 botones `[+ Rol]` `[+ Persona]` `[+ Herramienta]` `[+ Overhead]` del editor abren el drawer con `initialTab` preseleccionada. Persona sigue como variant separada (Autocomplete simple sobre `team_members`) porque no viene del catálogo sellable.
+- **Role gating**: la spec usa `finance_manager` y `finance`. En `src/config/role-codes.ts` solo existen `FINANCE_ADMIN`, `FINANCE_ANALYST`, `EFEONCE_ADMIN`. Uso esos tres en `canViewCostStack()`; si luego aparece un rol `finance_manager` operativo, se agrega al helper sin tocar consumers.
+- **Currencies**: drawer actual acepta `CLP|USD|CLF`. Extiendo a 6 (`CLP|USD|CLF|COP|MXN|PEN`) alineado con `PricingOutputCurrency` del engine v2. `CurrencySwitcher` ya refleja esto.
+- **Line types**: el engine v2 usa `role|person|tool|overhead_addon|direct_cost`; la persistencia (`quotation_line_items`) usa `person|role|deliverable|direct_cost`. Para MVP, al persistir `tool` y `overhead_addon` los mapeo a `direct_cost` + `metadata.pricingV2LineType` + `metadata.sku` (stored en `description` JSON estructurado). Cero cambio de schema. La UI del builder mantiene los 4 modos visualmente; el flattening ocurre al submit.
+- **Entitlement**: uso role check directo (Opción A, MVP). `finance.cost_stack.view` capability queda como follow-up si aparece necesidad de governance fina (ej. override por user).
+
 <!-- ═══════════════════════════════════════════════════════════
      ZONE 0 — IDENTITY & TRIAGE
      ═══════════════════════════════════════════════════════════ -->
 
 ## Status
 
-- Lifecycle: `to-do`
+- Lifecycle: `in-progress`
 - Priority: `P1`
 - Impact: `Muy Alto`
 - Effort: `Alto`

--- a/src/app/api/finance/quotes/pricing/lookup/route.ts
+++ b/src/app/api/finance/quotes/pricing/lookup/route.ts
@@ -1,0 +1,217 @@
+import 'server-only'
+
+import { NextResponse } from 'next/server'
+
+import { listOverheadAddons } from '@/lib/commercial/overhead-addons-store'
+import { listEmploymentTypes, listSellableRoles } from '@/lib/commercial/sellable-roles-store'
+import { listToolCatalog } from '@/lib/commercial/tool-catalog-store'
+import { runGreenhousePostgresQuery } from '@/lib/postgres/client'
+import { requireFinanceTenantContext } from '@/lib/tenant/authorization'
+
+export const dynamic = 'force-dynamic'
+
+const LOOKUP_TYPES = ['role', 'tool', 'addon', 'person', 'employment_type'] as const
+
+type LookupType = (typeof LOOKUP_TYPES)[number]
+
+interface LookupItem {
+  sku: string
+  label: string
+  description?: string | null
+  category?: string | null
+  metadata?: Record<string, unknown>
+}
+
+const isLookupType = (value: string | null): value is LookupType =>
+  typeof value === 'string' && (LOOKUP_TYPES as readonly string[]).includes(value)
+
+const matches = (haystack: string | null | undefined, needle: string): boolean => {
+  if (!needle) return true
+
+  return (haystack ?? '').toLowerCase().includes(needle.toLowerCase())
+}
+
+const lookupRoles = async (query: string): Promise<LookupItem[]> => {
+  const rows = await listSellableRoles({ activeOnly: true })
+
+  return rows
+    .filter(
+      row =>
+        matches(row.roleSku, query) ||
+        matches(row.roleLabelEs, query) ||
+        matches(row.roleLabelEn, query) ||
+        matches(row.category, query)
+    )
+    .map(row => ({
+      sku: row.roleSku,
+      label: row.roleLabelEs,
+      description: row.roleLabelEn ?? null,
+      category: row.category,
+      metadata: {
+        tier: row.tier,
+        tierLabel: row.tierLabel,
+        canSellAsStaff: row.canSellAsStaff,
+        canSellAsServiceComponent: row.canSellAsServiceComponent
+      }
+    }))
+}
+
+const matchesBusinessLine = (applicable: readonly string[] | null | undefined, businessLineCode: string): boolean => {
+  if (!applicable || applicable.length === 0) return true
+
+  return applicable.includes(businessLineCode)
+}
+
+const lookupTools = async (query: string, businessLineCode: string | null): Promise<LookupItem[]> => {
+  const rows = await listToolCatalog({ active: true })
+
+  return rows
+    .filter(row => {
+      const textMatch =
+        matches(row.toolSku, query) ||
+        matches(row.toolName, query) ||
+        matches(row.vendor, query) ||
+        matches(row.toolCategory, query)
+
+      if (!textMatch) return false
+      if (!businessLineCode) return true
+
+      const applicable = (row as { applicableBusinessLines?: readonly string[] | null }).applicableBusinessLines
+
+      return matchesBusinessLine(applicable, businessLineCode)
+    })
+    .map(row => ({
+      sku: row.toolSku ?? row.toolId,
+      label: row.toolName,
+      description: row.vendor,
+      category: row.toolCategory,
+      metadata: {
+        costModel: row.costModel,
+        subscriptionAmount: row.subscriptionAmount,
+        subscriptionCurrency: row.subscriptionCurrency,
+        vendor: row.vendor
+      }
+    }))
+}
+
+const lookupAddons = async (query: string): Promise<LookupItem[]> => {
+  const rows = await listOverheadAddons({ active: true })
+
+  return rows
+    .filter(
+      row =>
+        matches(row.addonSku, query) || matches(row.addonName, query) || matches(row.category, query)
+    )
+    .map(row => ({
+      sku: row.addonSku,
+      label: row.addonName,
+      description: row.category,
+      category: row.addonType,
+      metadata: {
+        unit: row.unit,
+        costInternalUsd: row.costInternalUsd,
+        marginPct: row.marginPct,
+        finalPriceUsd: row.finalPriceUsd,
+        finalPricePct: row.finalPricePct
+      }
+    }))
+}
+
+const lookupEmploymentTypes = async (query: string): Promise<LookupItem[]> => {
+  const rows = await listEmploymentTypes({ activeOnly: true })
+
+  return rows
+    .filter(
+      row =>
+        matches(row.employmentTypeCode, query) ||
+        matches(row.labelEs, query) ||
+        matches(row.labelEn, query)
+    )
+    .map(row => ({
+      sku: row.employmentTypeCode,
+      label: row.labelEs,
+      description: row.labelEn ?? null,
+      category: row.countryCode,
+      metadata: {
+        paymentCurrency: row.paymentCurrency,
+        appliesPrevisional: row.appliesPrevisional,
+        appliesBonuses: row.appliesBonuses
+      }
+    }))
+}
+
+const lookupPeople = async (query: string, limit: number): Promise<LookupItem[]> => {
+  const pattern = `%${query.replace(/[%_]/g, match => `\\${match}`)}%`
+
+  const rows = await runGreenhousePostgresQuery<{
+    member_id: string
+    display_name: string | null
+    email: string | null
+    role_title: string | null
+    department_name: string | null
+  }>(
+    `SELECT member_id, display_name, email, role_title, department_name
+       FROM greenhouse_core.team_members
+      WHERE active = TRUE
+        AND (
+          display_name ILIKE $1
+          OR email ILIKE $1
+          OR role_title ILIKE $1
+        )
+      ORDER BY display_name NULLS LAST
+      LIMIT $2`,
+    [pattern, limit]
+  )
+
+  return rows.map(row => ({
+    sku: row.member_id,
+    label: row.display_name ?? 'Sin nombre',
+    description: row.email,
+    category: row.role_title ?? 'Sin cargo',
+    metadata: {
+      department: row.department_name
+    }
+  }))
+}
+
+export async function GET(request: Request) {
+  const { tenant, errorResponse } = await requireFinanceTenantContext()
+
+  if (!tenant) {
+    return errorResponse || NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const type = searchParams.get('type')
+  const query = (searchParams.get('query') ?? '').trim()
+  const businessLineCode = searchParams.get('businessLineCode')
+  const limit = Math.min(50, Math.max(1, Number(searchParams.get('limit') ?? 10)))
+
+  if (!isLookupType(type)) {
+    return NextResponse.json(
+      { error: `type must be one of: ${LOOKUP_TYPES.join(', ')}` },
+      { status: 400 }
+    )
+  }
+
+  let items: LookupItem[] = []
+
+  try {
+    if (type === 'role') items = await lookupRoles(query)
+    else if (type === 'tool') items = await lookupTools(query, businessLineCode)
+    else if (type === 'addon') items = await lookupAddons(query)
+    else if (type === 'employment_type') items = await lookupEmploymentTypes(query)
+    else if (type === 'person') items = await lookupPeople(query, limit)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Lookup failed.'
+
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+
+  const sliced = items.slice(0, limit)
+
+  return NextResponse.json(
+    { items: sliced, hasMore: items.length > limit },
+    { headers: { 'Cache-Control': 'private, max-age=300' } }
+  )
+}

--- a/src/app/api/finance/quotes/pricing/simulate/route.ts
+++ b/src/app/api/finance/quotes/pricing/simulate/route.ts
@@ -1,0 +1,80 @@
+import 'server-only'
+
+import { NextResponse } from 'next/server'
+
+import type {
+  PricingEngineInputV2,
+  PricingEngineOutputV2,
+  PricingLineOutputV2
+} from '@/lib/finance/pricing/contracts'
+import { buildPricingEngineOutputV2 } from '@/lib/finance/pricing/pricing-engine-v2'
+import { canViewCostStack, requireFinanceTenantContext } from '@/lib/tenant/authorization'
+
+export const dynamic = 'force-dynamic'
+
+type SanitizedPricingLineOutput = Omit<PricingLineOutputV2, 'costStack'> & {
+  costStack?: PricingLineOutputV2['costStack']
+}
+
+type SanitizedPricingEngineOutput = Omit<PricingEngineOutputV2, 'lines'> & {
+  lines: SanitizedPricingLineOutput[]
+}
+
+const stripCostStack = (output: PricingEngineOutputV2): SanitizedPricingEngineOutput => ({
+  ...output,
+  lines: output.lines.map(({ costStack, ...rest }) => {
+    void costStack
+
+    return rest
+  })
+})
+
+const isValidInput = (payload: unknown): payload is PricingEngineInputV2 => {
+  if (!payload || typeof payload !== 'object') return false
+  const candidate = payload as Partial<PricingEngineInputV2>
+
+  return (
+    typeof candidate.commercialModel === 'string' &&
+    typeof candidate.countryFactorCode === 'string' &&
+    typeof candidate.outputCurrency === 'string' &&
+    typeof candidate.quoteDate === 'string' &&
+    Array.isArray(candidate.lines)
+  )
+}
+
+export async function POST(request: Request) {
+  const { tenant, errorResponse } = await requireFinanceTenantContext()
+
+  if (!tenant) {
+    return errorResponse || NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload.' }, { status: 400 })
+  }
+
+  if (!isValidInput(body)) {
+    return NextResponse.json(
+      {
+        error:
+          'Missing required fields. Expected { commercialModel, countryFactorCode, outputCurrency, quoteDate, lines[] }.'
+      },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const output = await buildPricingEngineOutputV2(body)
+    const payload = canViewCostStack(tenant) ? output : stripCostStack(output)
+
+    return NextResponse.json(payload)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Pricing engine simulation failed.'
+
+    return NextResponse.json({ error: message }, { status: 422 })
+  }
+}

--- a/src/components/greenhouse/pricing/CostStackPanel.tsx
+++ b/src/components/greenhouse/pricing/CostStackPanel.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Typography from '@mui/material/Typography'
+
+import type { PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
+import { GH_PRICING } from '@/config/greenhouse-nomenclature'
+
+import MarginIndicatorBadge from './MarginIndicatorBadge'
+
+export interface CostStackLine {
+  itemId: string
+  label: string
+  costBase: number
+  feeAmount: number
+  feeType: 'percent' | 'flat'
+  total: number
+}
+
+export interface CostStackTotals {
+  totalCost: number
+  priceToClient: number
+  grossMargin: number
+  marginPct: number
+}
+
+export interface CostStackTierFit {
+  tierCode: string
+  label: string
+  marginMin: number
+  marginOpt: number
+  marginMax: number
+}
+
+export interface CostStackPanelProps {
+  lines: CostStackLine[]
+  totals: CostStackTotals
+  tierFit?: CostStackTierFit
+  currency: PricingOutputCurrency
+
+  /** `quote-builder` (default): accordion collapsed. `admin-preview`: siempre expandido, sin accordion. */
+  variant?: 'quote-builder' | 'admin-preview'
+  defaultExpanded?: boolean
+}
+
+const CURRENCY_LOCALE: Record<PricingOutputCurrency, string> = {
+  CLP: 'es-CL',
+  USD: 'en-US',
+  CLF: 'es-CL',
+  COP: 'es-CO',
+  MXN: 'es-MX',
+  PEN: 'es-PE'
+}
+
+const formatMoney = (amount: number, currency: PricingOutputCurrency): string => {
+  const locale = CURRENCY_LOCALE[currency] ?? 'es-CL'
+
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0
+    }).format(amount)
+  } catch {
+    // CLF no tiene soporte ISO — fallback a número + suffix
+    return `${new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(amount)} ${currency}`
+  }
+}
+
+const formatPct = (value: number): string =>
+  new Intl.NumberFormat('es-CL', { style: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(value)
+
+const formatFeeCell = (line: CostStackLine): string => {
+  if (line.feeType === 'percent') {
+    return formatPct(line.costBase > 0 ? line.feeAmount / line.costBase : 0)
+  }
+
+  return 'flat'
+}
+
+const Body = ({
+  lines,
+  totals,
+  tierFit,
+  currency
+}: Pick<CostStackPanelProps, 'lines' | 'totals' | 'tierFit' | 'currency'>): ReactNode => (
+  <Stack spacing={2}>
+    {lines.length === 0 ? (
+      <Typography variant='body2' color='text.secondary'>
+        {GH_PRICING.builderEmptyLineItems}
+      </Typography>
+    ) : (
+      <Table size='small' aria-label={GH_PRICING.costStackTitle}>
+        <TableHead>
+          <TableRow>
+            <TableCell scope='col'>Ítem</TableCell>
+            <TableCell scope='col' align='right'>
+              Costo
+            </TableCell>
+            <TableCell scope='col' align='right'>
+              Fee
+            </TableCell>
+            <TableCell scope='col' align='right'>
+              Total
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {lines.map(line => (
+            <TableRow key={line.itemId}>
+              <TableCell>{line.label}</TableCell>
+              <TableCell align='right'>{formatMoney(line.costBase, currency)}</TableCell>
+              <TableCell align='right'>{formatFeeCell(line)}</TableCell>
+              <TableCell align='right'>{formatMoney(line.total, currency)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )}
+
+    <Divider />
+
+    <Stack spacing={1}>
+      <Row label={GH_PRICING.costStackTotalCost} value={formatMoney(totals.totalCost, currency)} />
+      <Row label={GH_PRICING.costStackPriceToClient} value={formatMoney(totals.priceToClient, currency)} />
+      <Row
+        label={GH_PRICING.costStackGrossMargin}
+        value={`${formatMoney(totals.grossMargin, currency)} (${formatPct(totals.marginPct)})`}
+      />
+      {tierFit ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+          <Typography variant='body2' color='text.secondary'>
+            {GH_PRICING.costStackTierFit}
+          </Typography>
+          <Stack direction='row' spacing={1} alignItems='center'>
+            <Chip size='small' label={tierFit.label} />
+            <MarginIndicatorBadge
+              marginPct={totals.marginPct}
+              target={{ min: tierFit.marginMin, opt: tierFit.marginOpt, max: tierFit.marginMax }}
+              size='sm'
+            />
+          </Stack>
+        </Box>
+      ) : null}
+    </Stack>
+  </Stack>
+)
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
+    <Typography variant='body2' color='text.secondary'>
+      {label}
+    </Typography>
+    <Typography variant='body2' sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
+      {value}
+    </Typography>
+  </Box>
+)
+
+/**
+ * Panel de desglose de costo interno. Gating del acceso lo hace el caller (ver
+ * `canViewCostStack` en `@/lib/tenant/authorization` y sanitización del endpoint
+ * `/api/finance/quotes/pricing/simulate`). Si el caller no tiene permiso, no
+ * renderiza este componente en absoluto — el componente asume que la decisión
+ * de visibilidad ya se tomó.
+ */
+const CostStackPanel = ({
+  lines,
+  totals,
+  tierFit,
+  currency,
+  variant = 'quote-builder',
+  defaultExpanded = false
+}: CostStackPanelProps) => {
+  if (variant === 'admin-preview') {
+    return (
+      <Box
+        component='section'
+        role='region'
+        aria-label={GH_PRICING.costStackTitle}
+        sx={theme => ({
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: 1,
+          p: 3
+        })}
+      >
+        <Typography variant='h6' sx={{ mb: 2 }}>
+          {GH_PRICING.costStackTitle}
+        </Typography>
+        <Body lines={lines} totals={totals} tierFit={tierFit} currency={currency} />
+      </Box>
+    )
+  }
+
+  return (
+    <Accordion
+      defaultExpanded={defaultExpanded}
+      disableGutters
+      elevation={0}
+      sx={theme => ({
+        border: `1px solid ${theme.palette.divider}`,
+        '&::before': { display: 'none' }
+      })}
+    >
+      <AccordionSummary
+        expandIcon={<i className='tabler-chevron-down' aria-hidden='true' />}
+        aria-label={GH_PRICING.costStackTitle}
+      >
+        <Typography variant='subtitle2'>{GH_PRICING.costStackTitle}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Body lines={lines} totals={totals} tierFit={tierFit} currency={currency} />
+      </AccordionDetails>
+    </Accordion>
+  )
+}
+
+export default CostStackPanel

--- a/src/components/greenhouse/pricing/CurrencySwitcher.test.tsx
+++ b/src/components/greenhouse/pricing/CurrencySwitcher.test.tsx
@@ -65,6 +65,18 @@ describe('CurrencySwitcher', () => {
     expect(getByText(/945,20/)).toBeInTheDocument()
   })
 
+  it('exposes the 6 LatAm-focused currencies aligned with pricing engine v2', () => {
+    const { getByRole, getAllByRole } = renderWithTheme(
+      <CurrencySwitcher value='CLP' onChange={() => {}} />
+    )
+
+    fireEvent.mouseDown(getByRole('combobox'))
+    const options = getAllByRole('option')
+    const codes = options.map(o => o.textContent?.split('·')[0]?.trim())
+
+    expect(codes).toEqual(['CLP', 'USD', 'CLF', 'COP', 'MXN', 'PEN'])
+  })
+
   it('disables the select when disabled=true', () => {
     const { getByRole } = renderWithTheme(
       <CurrencySwitcher value='CLP' onChange={() => {}} disabled />

--- a/src/components/greenhouse/pricing/CurrencySwitcher.test.tsx
+++ b/src/components/greenhouse/pricing/CurrencySwitcher.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent } from '@testing-library/react'
+
+import { renderWithTheme } from '@/test/render'
+
+import CurrencySwitcher from './CurrencySwitcher'
+
+afterEach(cleanup)
+
+describe('CurrencySwitcher', () => {
+  it('renders the visible label "Moneda" from nomenclature', () => {
+    const { getByLabelText } = renderWithTheme(<CurrencySwitcher value='CLP' onChange={() => {}} />)
+
+    expect(getByLabelText('Moneda')).toBeInTheDocument()
+  })
+
+  it('reflects the current value in the select', () => {
+    const { getByRole } = renderWithTheme(<CurrencySwitcher value='USD' onChange={() => {}} />)
+
+    expect(getByRole('combobox')).toHaveTextContent(/USD/)
+  })
+
+  it('invokes onChange with the new currency when selection changes', () => {
+    const onChange = vi.fn()
+
+    const { getByRole, getAllByRole } = renderWithTheme(
+      <CurrencySwitcher value='CLP' onChange={onChange} />
+    )
+
+    fireEvent.mouseDown(getByRole('combobox'))
+    const options = getAllByRole('option')
+    const usdOption = options.find(o => o.textContent?.includes('USD'))
+
+    expect(usdOption).toBeDefined()
+    fireEvent.click(usdOption!)
+
+    expect(onChange).toHaveBeenCalledWith('USD')
+  })
+
+  it('hides disclaimer when exchange rate snapshot base matches current value', () => {
+    const { queryByText } = renderWithTheme(
+      <CurrencySwitcher
+        value='CLP'
+        onChange={() => {}}
+        exchangeRateSnapshot={{ base: 'CLP', rate: 1, asOf: '2026-04-18' }}
+      />
+    )
+
+    expect(queryByText(/Vista interna/)).not.toBeInTheDocument()
+  })
+
+  it('shows disclaimer with base currency and formatted rate when view differs from snapshot', () => {
+    const { getByText } = renderWithTheme(
+      <CurrencySwitcher
+        value='USD'
+        onChange={() => {}}
+        exchangeRateSnapshot={{ base: 'CLP', rate: 945.2, asOf: '2026-04-18' }}
+      />
+    )
+
+    expect(getByText(/Vista interna/)).toBeInTheDocument()
+    expect(getByText(/CLP/)).toBeInTheDocument()
+    expect(getByText(/945,20/)).toBeInTheDocument()
+  })
+
+  it('disables the select when disabled=true', () => {
+    const { getByRole } = renderWithTheme(
+      <CurrencySwitcher value='CLP' onChange={() => {}} disabled />
+    )
+
+    expect(getByRole('combobox')).toHaveAttribute('aria-disabled', 'true')
+  })
+})

--- a/src/components/greenhouse/pricing/CurrencySwitcher.tsx
+++ b/src/components/greenhouse/pricing/CurrencySwitcher.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import MenuItem from '@mui/material/MenuItem'
+
+import CustomTextField from '@core/components/mui/TextField'
+
+import { GH_PRICING } from '@/config/greenhouse-nomenclature'
+
+export type Currency = 'CLP' | 'USD' | 'EUR' | 'GBP'
+
+export interface CurrencySwitcherProps {
+  value: Currency
+  onChange: (currency: Currency) => void
+  disabled?: boolean
+
+  /**
+   * Snapshot de la tasa de cambio asociada a la cotización.
+   * Cuando `base !== value`, se muestra un helper text indicando que la vista interna
+   * difiere de la cotización canónica enviada al cliente.
+   */
+  exchangeRateSnapshot?: { base: string; rate: number; asOf: string }
+  size?: 'small' | 'medium'
+  fullWidth?: boolean
+}
+
+const CURRENCY_OPTIONS: Array<{ value: Currency; label: string }> = [
+  { value: 'CLP', label: 'CLP · Peso chileno' },
+  { value: 'USD', label: 'USD · Dólar estadounidense' },
+  { value: 'EUR', label: 'EUR · Euro' },
+  { value: 'GBP', label: 'GBP · Libra esterlina' }
+]
+
+const formatAsOf = (isoDate: string): string => {
+  try {
+    const date = new Date(isoDate)
+
+    if (Number.isNaN(date.getTime())) return isoDate
+
+    return new Intl.DateTimeFormat('es-CL', { day: '2-digit', month: 'short' }).format(date)
+  } catch {
+    return isoDate
+  }
+}
+
+const formatRate = (rate: number): string =>
+  new Intl.NumberFormat('es-CL', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(rate)
+
+const CurrencySwitcher = ({
+  value,
+  onChange,
+  disabled = false,
+  exchangeRateSnapshot,
+  size = 'small',
+  fullWidth = false
+}: CurrencySwitcherProps) => {
+  const showDisclaimer = exchangeRateSnapshot !== undefined && exchangeRateSnapshot.base !== value
+
+  const helperText = showDisclaimer
+    ? `Vista interna — la cotización enviada usa ${exchangeRateSnapshot.base} (tasa ${formatRate(
+        exchangeRateSnapshot.rate
+      )} al ${formatAsOf(exchangeRateSnapshot.asOf)}).`
+    : undefined
+
+  return (
+    <CustomTextField
+      select
+      size={size}
+      fullWidth={fullWidth}
+      label={GH_PRICING.currencyLabel}
+      value={value}
+      disabled={disabled}
+      onChange={e => onChange(e.target.value as Currency)}
+      helperText={helperText}
+      sx={{ minWidth: 180 }}
+    >
+      {CURRENCY_OPTIONS.map(opt => (
+        <MenuItem key={opt.value} value={opt.value}>
+          {opt.label}
+        </MenuItem>
+      ))}
+    </CustomTextField>
+  )
+}
+
+export default CurrencySwitcher

--- a/src/components/greenhouse/pricing/CurrencySwitcher.tsx
+++ b/src/components/greenhouse/pricing/CurrencySwitcher.tsx
@@ -5,8 +5,13 @@ import MenuItem from '@mui/material/MenuItem'
 import CustomTextField from '@core/components/mui/TextField'
 
 import { GH_PRICING } from '@/config/greenhouse-nomenclature'
+import type { PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
 
-export type Currency = 'CLP' | 'USD' | 'EUR' | 'GBP'
+/**
+ * Alias re-exported del engine v2 para que consumers del builder no tengan que
+ * importar el tipo desde dos módulos distintos.
+ */
+export type Currency = PricingOutputCurrency
 
 export interface CurrencySwitcherProps {
   value: Currency
@@ -23,11 +28,15 @@ export interface CurrencySwitcherProps {
   fullWidth?: boolean
 }
 
+// Orden operativo: local + internacional primero, luego LatAm.
+// Alineado con PRICING_OUTPUT_CURRENCIES del engine v2 (6 monedas).
 const CURRENCY_OPTIONS: Array<{ value: Currency; label: string }> = [
   { value: 'CLP', label: 'CLP · Peso chileno' },
   { value: 'USD', label: 'USD · Dólar estadounidense' },
-  { value: 'EUR', label: 'EUR · Euro' },
-  { value: 'GBP', label: 'GBP · Libra esterlina' }
+  { value: 'CLF', label: 'CLF · UF' },
+  { value: 'COP', label: 'COP · Peso colombiano' },
+  { value: 'MXN', label: 'MXN · Peso mexicano' },
+  { value: 'PEN', label: 'PEN · Sol peruano' }
 ]
 
 const formatAsOf = (isoDate: string): string => {

--- a/src/components/greenhouse/pricing/MarginIndicatorBadge.test.tsx
+++ b/src/components/greenhouse/pricing/MarginIndicatorBadge.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithTheme } from '@/test/render'
+
+import MarginIndicatorBadge from './MarginIndicatorBadge'
+
+afterEach(cleanup)
+
+const tierTarget = { min: 0.15, opt: 0.3, max: 0.4 }
+
+describe('MarginIndicatorBadge', () => {
+  it('classifies margin below min as critical with alert-triangle icon', () => {
+    const { container, getByText } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.1} target={tierTarget} />
+    )
+
+    expect(getByText(/Crítico/)).toBeInTheDocument()
+    expect(container.querySelector('.tabler-alert-triangle')).toBeInTheDocument()
+  })
+
+  it('classifies margin between min and opt as attention', () => {
+    const { getByText, container } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.2} target={tierTarget} />
+    )
+
+    expect(getByText(/Atención/)).toBeInTheDocument()
+    expect(container.querySelector('.tabler-alert-circle')).toBeInTheDocument()
+  })
+
+  it('classifies margin within optimal range as optimal', () => {
+    const { getByText, container } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.35} target={tierTarget} />
+    )
+
+    expect(getByText(/Óptimo/)).toBeInTheDocument()
+    expect(container.querySelector('.tabler-circle-check')).toBeInTheDocument()
+  })
+
+  it('classifies margin above max as overshoot with info-circle icon', () => {
+    const { getByText, container } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.5} target={tierTarget} />
+    )
+
+    expect(getByText(/Sobre meta/)).toBeInTheDocument()
+    expect(container.querySelector('.tabler-info-circle')).toBeInTheDocument()
+  })
+
+  it('hides status label when showLabel=false', () => {
+    const { queryByText } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.35} target={tierTarget} showLabel={false} />
+    )
+
+    expect(queryByText(/Óptimo/)).not.toBeInTheDocument()
+  })
+
+  it('exposes an accessible aria-label with percentage and status', () => {
+    const { getByLabelText } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.35} target={tierTarget} />
+    )
+
+    expect(getByLabelText(/Margen.*Óptimo/)).toBeInTheDocument()
+  })
+
+  it('treats margin exactly at min as attention (not critical)', () => {
+    const { getByText } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.15} target={tierTarget} />
+    )
+
+    expect(getByText(/Atención/)).toBeInTheDocument()
+  })
+
+  it('treats margin exactly at max as optimal (not overshoot)', () => {
+    const { getByText } = renderWithTheme(
+      <MarginIndicatorBadge marginPct={0.4} target={tierTarget} />
+    )
+
+    expect(getByText(/Óptimo/)).toBeInTheDocument()
+  })
+})

--- a/src/components/greenhouse/pricing/MarginIndicatorBadge.tsx
+++ b/src/components/greenhouse/pricing/MarginIndicatorBadge.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import Chip from '@mui/material/Chip'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import { GH_COLORS, GH_PRICING } from '@/config/greenhouse-nomenclature'
+
+export type MarginStatus = 'critical' | 'attention' | 'optimal' | 'overshoot'
+
+export interface MarginIndicatorBadgeProps {
+
+  /** Margen como fracción decimal. Ej: 0.32 = 32% */
+  marginPct: number
+
+  /** Meta de margen para el tier evaluado (todas en fracción decimal) */
+  target: { min: number; opt: number; max: number }
+
+  /** Tamaño del chip */
+  size?: 'sm' | 'md'
+
+  /** Si true (default), muestra el label de estado después del %. Si false, solo el %. */
+  showLabel?: boolean
+}
+
+const classifyMargin = (marginPct: number, target: MarginIndicatorBadgeProps['target']): MarginStatus => {
+  if (marginPct < target.min) return 'critical'
+  if (marginPct < target.opt) return 'attention'
+  if (marginPct <= target.max) return 'optimal'
+
+  return 'overshoot'
+}
+
+const STATUS_META: Record<MarginStatus, { icon: string; tone: 'error' | 'warning' | 'success' | 'info' }> = {
+  critical: { icon: 'tabler-alert-triangle', tone: 'error' },
+  attention: { icon: 'tabler-alert-circle', tone: 'warning' },
+  optimal: { icon: 'tabler-circle-check', tone: 'success' },
+  overshoot: { icon: 'tabler-info-circle', tone: 'info' }
+}
+
+const formatPct = (value: number) =>
+  new Intl.NumberFormat('es-CL', { style: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(value)
+
+const MarginIndicatorBadge = ({
+  marginPct,
+  target,
+  size = 'md',
+  showLabel = true
+}: MarginIndicatorBadgeProps) => {
+  const theme = useTheme()
+  const status = classifyMargin(marginPct, target)
+  const meta = STATUS_META[status]
+  const statusLabel = GH_PRICING.marginLabels[status]
+
+  const palette =
+    meta.tone === 'success'
+      ? GH_COLORS.semaphore.green
+      : meta.tone === 'warning'
+        ? GH_COLORS.semaphore.yellow
+        : meta.tone === 'error'
+          ? GH_COLORS.semaphore.red
+          : {
+              source: theme.palette.info.main,
+              bg: theme.palette.info.lighterOpacity ?? alpha(theme.palette.info.main, 0.12),
+              text: theme.palette.info.main
+            }
+
+  const pctText = formatPct(marginPct)
+  const label = showLabel ? `${pctText} · ${statusLabel}` : pctText
+  const ariaLabel = `Margen ${pctText} — ${statusLabel}`
+
+  return (
+    <Chip
+      size={size === 'sm' ? 'small' : 'medium'}
+      aria-label={ariaLabel}
+      label={label}
+      icon={<i className={`${meta.icon} text-[14px]`} aria-hidden='true' />}
+      sx={{
+        bgcolor: palette.bg,
+        color: palette.text,
+        border: `1px solid ${alpha(palette.source, 0.24)}`,
+        fontWeight: 500,
+        '& .MuiChip-icon': {
+          color: palette.text,
+          marginLeft: size === 'sm' ? '6px' : '8px'
+        }
+      }}
+    />
+  )
+}
+
+export default MarginIndicatorBadge

--- a/src/components/greenhouse/pricing/PricingCatalogNavCard.test.tsx
+++ b/src/components/greenhouse/pricing/PricingCatalogNavCard.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithTheme } from '@/test/render'
+
+import PricingCatalogNavCard from './PricingCatalogNavCard'
+
+afterEach(cleanup)
+
+describe('PricingCatalogNavCard', () => {
+  it('renders label, count, and icon', () => {
+    const { getByText, container } = renderWithTheme(
+      <PricingCatalogNavCard
+        href='/admin/pricing/roles'
+        label='Roles vendibles'
+        count={33}
+        icon='tabler-briefcase'
+      />
+    )
+
+    expect(getByText('Roles vendibles')).toBeInTheDocument()
+    expect(getByText('33')).toBeInTheDocument()
+    expect(container.querySelector('.tabler-briefcase')).toBeInTheDocument()
+  })
+
+  it('navigates to the provided href via anchor element', () => {
+    const { getByRole } = renderWithTheme(
+      <PricingCatalogNavCard
+        href='/admin/pricing/tools'
+        label='Catálogo de herramientas'
+        count={26}
+        icon='tabler-tool'
+      />
+    )
+
+    const link = getByRole('link')
+
+    expect(link).toHaveAttribute('href', '/admin/pricing/tools')
+  })
+
+  it('exposes an accessible label combining label and count', () => {
+    const { getByLabelText } = renderWithTheme(
+      <PricingCatalogNavCard
+        href='/admin/pricing/services'
+        label='Servicios empaquetados'
+        count={7}
+        icon='tabler-package'
+      />
+    )
+
+    expect(getByLabelText('Servicios empaquetados, 7')).toBeInTheDocument()
+  })
+
+  it('renders em-dash placeholder when count is undefined', () => {
+    const { getByText } = renderWithTheme(
+      <PricingCatalogNavCard
+        href='/admin/pricing/audit'
+        label='Historial de cambios'
+        icon='tabler-history'
+      />
+    )
+
+    expect(getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders optional description under label', () => {
+    const { getByText } = renderWithTheme(
+      <PricingCatalogNavCard
+        href='/admin/pricing/roles'
+        label='Roles vendibles'
+        count={33}
+        icon='tabler-briefcase'
+        description='Catálogo canónico de roles'
+      />
+    )
+
+    expect(getByText('Catálogo canónico de roles')).toBeInTheDocument()
+  })
+
+  it('formats numeric counts using es-CL locale', () => {
+    const { getByText } = renderWithTheme(
+      <PricingCatalogNavCard
+        href='/admin/pricing/roles'
+        label='Roles vendibles'
+        count={1234}
+        icon='tabler-briefcase'
+      />
+    )
+
+    expect(getByText('1.234')).toBeInTheDocument()
+  })
+})

--- a/src/components/greenhouse/pricing/PricingCatalogNavCard.tsx
+++ b/src/components/greenhouse/pricing/PricingCatalogNavCard.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+
+import Card from '@mui/material/Card'
+import CardActionArea from '@mui/material/CardActionArea'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+
+import type { ThemeColor } from '@core/types'
+
+import CustomAvatar from '@core/components/mui/Avatar'
+
+export interface PricingCatalogNavCardProps {
+
+  /** Ruta destino del catálogo (ej: `/admin/pricing/roles`) */
+  href: string
+
+  /** Label del catálogo (ej: "Roles vendibles") */
+  label: string
+
+  /** Número de entidades activas (ej: 33). Se formatea como integer. Acepta string para "—" o placeholders. */
+  count?: number | string
+
+  /** Icono Tabler (ej: "tabler-briefcase") */
+  icon: string
+
+  /** Color del avatar — default `primary` */
+  color?: ThemeColor
+
+  /** Descripción corta opcional (una línea) — default undefined */
+  description?: string
+}
+
+const formatCount = (count: number | string | undefined): string => {
+  if (count === undefined) return '—'
+  if (typeof count === 'string') return count
+
+  return new Intl.NumberFormat('es-CL', { maximumFractionDigits: 0 }).format(count)
+}
+
+const PricingCatalogNavCard = ({
+  href,
+  label,
+  count,
+  icon,
+  color = 'primary',
+  description
+}: PricingCatalogNavCardProps) => {
+  const accessibleLabel = count !== undefined ? `${label}, ${formatCount(count)}` : label
+
+  return (
+    <Card
+      elevation={0}
+      sx={theme => ({
+        border: `1px solid ${theme.palette.divider}`,
+        transition: theme.transitions.create(['border-color', 'box-shadow'], { duration: 150 }),
+        '&:hover': {
+          borderColor: theme.palette[color].main,
+          boxShadow: theme.shadows[2]
+        }
+      })}
+    >
+      <CardActionArea
+        component={Link}
+        href={href}
+        aria-label={accessibleLabel}
+        sx={{ minHeight: 96, p: 0 }}
+      >
+        <CardContent
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2
+          }}
+        >
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 0.5 }}>
+            <Typography variant='h5'>{formatCount(count)}</Typography>
+            <Typography variant='body2'>{label}</Typography>
+            {description ? (
+              <Typography variant='caption' color='text.secondary'>
+                {description}
+              </Typography>
+            ) : null}
+          </Box>
+          <CustomAvatar variant='rounded' skin='light' color={color}>
+            <i className={icon} aria-hidden='true' />
+          </CustomAvatar>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+export default PricingCatalogNavCard

--- a/src/components/greenhouse/pricing/SellableItemPickerDrawer.tsx
+++ b/src/components/greenhouse/pricing/SellableItemPickerDrawer.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import Divider from '@mui/material/Divider'
+import Drawer from '@mui/material/Drawer'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
+import Typography from '@mui/material/Typography'
+
+import { GH_PRICING } from '@/config/greenhouse-nomenclature'
+
+import DebouncedInput from '@/components/DebouncedInput'
+import EmptyState from '@/components/greenhouse/EmptyState'
+
+import SellableItemRow, { type SellableItemVariant } from './SellableItemRow'
+
+export type SellableItemPickerTab = 'roles' | 'tools' | 'overhead' | 'services'
+
+export interface SellableSelection {
+  tab: SellableItemPickerTab
+  sku: string
+  label: string
+  metadata?: Record<string, unknown>
+}
+
+export interface SellableItemPickerDrawerProps {
+  open: boolean
+  onClose: () => void
+  onSelect: (items: SellableSelection[]) => void
+  initialTab?: SellableItemPickerTab
+
+  /** SKUs ya agregados en el quote — se renderizan disabled */
+  excludeSkus?: string[]
+
+  /** Filtro por línea de negocio (solo aplica a tools y overhead) */
+  businessLineCode?: string | null
+
+  /** Endpoint override para testing */
+  lookupEndpoint?: string
+}
+
+interface LookupResponseItem {
+  sku: string
+  label: string
+  description?: string | null
+  category?: string | null
+  metadata?: Record<string, unknown>
+}
+
+const TAB_TO_LOOKUP_TYPE: Record<SellableItemPickerTab, string> = {
+  roles: 'role',
+  tools: 'tool',
+  overhead: 'addon',
+  services: 'service'
+}
+
+const TAB_TO_ROW_VARIANT: Record<SellableItemPickerTab, SellableItemVariant> = {
+  roles: 'role',
+  tools: 'tool',
+  overhead: 'overhead',
+  services: 'service'
+}
+
+const TABS: Array<{ value: SellableItemPickerTab; label: string }> = [
+  { value: 'roles', label: GH_PRICING.pickerTabs.roles },
+  { value: 'tools', label: GH_PRICING.pickerTabs.tools },
+  { value: 'overhead', label: GH_PRICING.pickerTabs.overhead },
+  { value: 'services', label: GH_PRICING.pickerTabs.services }
+]
+
+const SellableItemPickerDrawer = ({
+  open,
+  onClose,
+  onSelect,
+  initialTab = 'roles',
+  excludeSkus = [],
+  businessLineCode = null,
+  lookupEndpoint = '/api/finance/quotes/pricing/lookup'
+}: SellableItemPickerDrawerProps) => {
+  const [activeTab, setActiveTab] = useState<SellableItemPickerTab>(initialTab)
+  const [query, setQuery] = useState('')
+  const [items, setItems] = useState<LookupResponseItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedSkus, setSelectedSkus] = useState<Set<string>>(new Set())
+
+  // Reset state when drawer opens
+  useEffect(() => {
+    if (open) {
+      setActiveTab(initialTab)
+      setQuery('')
+      setSelectedSkus(new Set())
+      setError(null)
+    }
+  }, [open, initialTab])
+
+  // Fetch items on tab / query / BL change
+  useEffect(() => {
+    if (!open) return
+
+    // "services" tab no tiene lookup todavía (TASK-465 lo agrega). Placeholder UX.
+    if (activeTab === 'services') {
+      setItems([])
+      setLoading(false)
+      setError(null)
+
+      return
+    }
+
+    const controller = new AbortController()
+
+    const timer = setTimeout(async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const params = new URLSearchParams({
+          type: TAB_TO_LOOKUP_TYPE[activeTab],
+          query,
+          limit: '30'
+        })
+
+        if (businessLineCode) params.set('businessLineCode', businessLineCode)
+
+        const response = await fetch(`${lookupEndpoint}?${params}`, { signal: controller.signal })
+
+        if (!response.ok) {
+          const body = (await response.json().catch(() => ({}))) as { error?: string }
+
+          throw new Error(body.error ?? `Lookup failed: HTTP ${response.status}`)
+        }
+
+        const payload = (await response.json()) as { items: LookupResponseItem[] }
+
+        if (!controller.signal.aborted) setItems(payload.items)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : 'Lookup failed.')
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }, 250)
+
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [open, activeTab, query, businessLineCode, lookupEndpoint])
+
+  const excludedSet = useMemo(() => new Set(excludeSkus), [excludeSkus])
+
+  const handleToggleSelect = useCallback((sku: string) => {
+    setSelectedSkus(prev => {
+      const next = new Set(prev)
+
+      if (next.has(sku)) next.delete(sku)
+      else next.add(sku)
+
+      return next
+    })
+  }, [])
+
+  const handleSubmit = () => {
+    const selections: SellableSelection[] = items
+      .filter(item => selectedSkus.has(item.sku))
+      .map(item => ({
+        tab: activeTab,
+        sku: item.sku,
+        label: item.label,
+        metadata: item.metadata
+      }))
+
+    onSelect(selections)
+    onClose()
+  }
+
+  const selectedCount = selectedSkus.size
+
+  return (
+    <Drawer
+      anchor='right'
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { width: { xs: '100%', sm: 480 } } }}
+    >
+      <Box
+        role='dialog'
+        aria-label={GH_PRICING.pickerTitle}
+        sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      >
+        {/* Header */}
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', p: 3 }}>
+          <Typography variant='h6'>{GH_PRICING.pickerTitle}</Typography>
+          <IconButton onClick={onClose} aria-label={GH_PRICING.pickerClose}>
+            <i className='tabler-x' aria-hidden='true' />
+          </IconButton>
+        </Box>
+
+        <Tabs
+          value={activeTab}
+          onChange={(_, value: SellableItemPickerTab) => setActiveTab(value)}
+          variant='fullWidth'
+          aria-label={GH_PRICING.pickerTabsAriaLabel}
+        >
+          {TABS.map(tab => (
+            <Tab key={tab.value} label={tab.label} value={tab.value} />
+          ))}
+        </Tabs>
+
+        <Divider />
+
+        {/* Search */}
+        <Box sx={{ p: 3 }}>
+          <DebouncedInput
+            value={query}
+            onChange={value => setQuery(String(value))}
+            placeholder={GH_PRICING.pickerSearchPlaceholder}
+            fullWidth
+            size='small'
+          />
+        </Box>
+
+        {/* Body */}
+        <Box sx={{ flex: 1, overflowY: 'auto', px: 3, pb: 2 }}>
+          {loading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }} role='status' aria-label={GH_PRICING.pickerLoadingAria}>
+              <CircularProgress size={32} />
+            </Box>
+          ) : error ? (
+            <Box sx={{ py: 4 }} role='alert'>
+              <Typography variant='body2' color='error'>
+                {error}
+              </Typography>
+            </Box>
+          ) : items.length === 0 ? (
+            <EmptyState
+              icon='tabler-database-off'
+              title={GH_PRICING.pickerEmpty}
+              description={activeTab === 'services' ? GH_PRICING.pickerServicesPlaceholder : GH_PRICING.pickerEmptyCta}
+            />
+          ) : (
+            <Stack spacing={1}>
+              {items.map(item => (
+                <SellableItemRow
+                  key={item.sku}
+                  variant={TAB_TO_ROW_VARIANT[activeTab]}
+                  sku={item.sku}
+                  label={item.label}
+                  description={item.description ?? null}
+                  category={item.category ?? null}
+                  selected={selectedSkus.has(item.sku)}
+                  disabled={excludedSet.has(item.sku)}
+                  onSelect={handleToggleSelect}
+                />
+              ))}
+            </Stack>
+          )}
+        </Box>
+
+        <Divider />
+
+        {/* Footer */}
+        <Box sx={{ p: 3, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>
+          <Typography variant='body2' color='text.secondary'>
+            {selectedCount === 0
+              ? GH_PRICING.pickerSelectionNone
+              : selectedCount === 1
+                ? GH_PRICING.pickerSelectionCountOne(selectedCount)
+                : GH_PRICING.pickerSelectionCountMany(selectedCount)}
+          </Typography>
+          <Stack direction='row' spacing={1}>
+            <Button variant='outlined' onClick={onClose}>
+              {GH_PRICING.pickerCancel}
+            </Button>
+            <Button variant='contained' onClick={handleSubmit} disabled={selectedCount === 0}>
+              {GH_PRICING.pickerSubmit}
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default SellableItemPickerDrawer

--- a/src/components/greenhouse/pricing/SellableItemRow.tsx
+++ b/src/components/greenhouse/pricing/SellableItemRow.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+export type SellableItemVariant = 'role' | 'tool' | 'overhead' | 'service'
+
+export interface SellableItemRowProps {
+  variant: SellableItemVariant
+
+  /** SKU o identificador estable */
+  sku: string
+
+  /** Label principal (nombre del ítem) */
+  label: string
+
+  /** Descripción secundaria — en roles suele ser el label en inglés, en tools el proveedor. */
+  description?: string | null
+
+  /** Categoría/tier/módulo — se renderiza como chip */
+  category?: string | null
+
+  /** Línea de precio (ya formateada por el caller) */
+  priceLabel?: string | null
+
+  /** Estado de selección — para pickers con multi-select */
+  selected?: boolean
+
+  /** Si está deshabilitado (ej. ya agregado al quote) */
+  disabled?: boolean
+
+  /** Handler de click/selección */
+  onSelect?: (sku: string) => void
+}
+
+const VARIANT_ICON: Record<SellableItemVariant, string> = {
+  role: 'tabler-user-check',
+  tool: 'tabler-tool',
+  overhead: 'tabler-plus-minus',
+  service: 'tabler-package'
+}
+
+const VARIANT_ARIA: Record<SellableItemVariant, string> = {
+  role: 'Rol vendible',
+  tool: 'Herramienta',
+  overhead: 'Overhead add-on',
+  service: 'Servicio empaquetado'
+}
+
+/**
+ * Row polimórfico para `SellableItemPickerDrawer`. Renderiza un ítem del catálogo
+ * (rol, herramienta, overhead, servicio) con icono + label + descripción + precio.
+ * Sin lógica de negocio — el caller maneja selección y filtrado.
+ */
+const SellableItemRow = ({
+  variant,
+  sku,
+  label,
+  description,
+  category,
+  priceLabel,
+  selected = false,
+  disabled = false,
+  onSelect
+}: SellableItemRowProps) => {
+  const handleClick = () => {
+    if (!disabled && onSelect) onSelect(sku)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled || !onSelect) return
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onSelect(sku)
+    }
+  }
+
+  return (
+    <Box
+      role='option'
+      tabIndex={disabled ? -1 : 0}
+      aria-label={`${VARIANT_ARIA[variant]} ${label}${description ? `, ${description}` : ''}`}
+      aria-selected={selected}
+      aria-disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      sx={theme => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        p: 2,
+        minHeight: 56,
+        borderRadius: 1,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+        bgcolor: selected ? theme.palette.primary.lighterOpacity : 'transparent',
+        border: `1px solid ${selected ? theme.palette.primary.main : 'transparent'}`,
+        transition: theme.transitions.create(['background-color', 'border-color'], { duration: 150 }),
+        '&:hover': disabled
+          ? undefined
+          : {
+              bgcolor: theme.palette.action.hover
+            },
+        '&:focus-visible': {
+          outline: `2px solid ${theme.palette.primary.main}`,
+          outlineOffset: 2
+        }
+      })}
+    >
+      <i
+        className={VARIANT_ICON[variant]}
+        aria-hidden='true'
+        style={{ fontSize: 20, flexShrink: 0, color: 'inherit' }}
+      />
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack direction='row' spacing={1} alignItems='center' sx={{ mb: 0.25 }}>
+          <Typography variant='body2' sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'text.secondary' }}>
+            {sku}
+          </Typography>
+          {category ? <Chip size='small' label={category} sx={{ height: 18, fontSize: '0.65rem' }} /> : null}
+        </Stack>
+
+        <Typography
+          variant='body2'
+          sx={{
+            fontWeight: 500,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {label}
+        </Typography>
+
+        {description ? (
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block' }}>
+            {description}
+          </Typography>
+        ) : null}
+      </Box>
+
+      {priceLabel ? (
+        <Typography variant='body2' sx={{ fontFamily: 'monospace', fontWeight: 500, whiteSpace: 'nowrap' }}>
+          {priceLabel}
+        </Typography>
+      ) : null}
+    </Box>
+  )
+}
+
+export default SellableItemRow

--- a/src/components/greenhouse/pricing/index.ts
+++ b/src/components/greenhouse/pricing/index.ts
@@ -1,0 +1,8 @@
+export { default as MarginIndicatorBadge } from './MarginIndicatorBadge'
+export type { MarginIndicatorBadgeProps, MarginStatus } from './MarginIndicatorBadge'
+
+export { default as CurrencySwitcher } from './CurrencySwitcher'
+export type { CurrencySwitcherProps, Currency } from './CurrencySwitcher'
+
+export { default as PricingCatalogNavCard } from './PricingCatalogNavCard'
+export type { PricingCatalogNavCardProps } from './PricingCatalogNavCard'

--- a/src/config/greenhouse-nomenclature.ts
+++ b/src/config/greenhouse-nomenclature.ts
@@ -1623,6 +1623,7 @@ export const GH_PRICING = {
   builderEmptyLineItemsCta: 'Agregar rol',
 
   // Sellable item picker (drawer con 4 tabs)
+  pickerTitle: 'Agregar ítem',
   pickerTabs: {
     roles: 'Roles',
     tools: 'Herramientas',
@@ -1632,6 +1633,15 @@ export const GH_PRICING = {
   pickerSearchPlaceholder: 'Buscar por SKU o nombre...',
   pickerEmpty: 'No hay ítems activos para este filtro',
   pickerEmptyCta: 'Ir al catálogo',
+  pickerServicesPlaceholder: 'Los servicios empaquetados se habilitan en TASK-465.',
+  pickerLoadingAria: 'Cargando catálogo',
+  pickerSelectionNone: 'Ningún ítem seleccionado',
+  pickerSelectionCountOne: (n: number) => `${n} ítem seleccionado`,
+  pickerSelectionCountMany: (n: number) => `${n} ítems seleccionados`,
+  pickerSubmit: 'Agregar seleccionados',
+  pickerCancel: 'Cancelar',
+  pickerClose: 'Cerrar',
+  pickerTabsAriaLabel: 'Categorías de ítems vendibles',
 
   // Cost stack (gated: solo finance/admin)
   costStackTitle: 'Detalle de costo (solo interno)',

--- a/src/hooks/usePricingSimulation.ts
+++ b/src/hooks/usePricingSimulation.ts
@@ -1,0 +1,102 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import type { PricingEngineInputV2, PricingEngineOutputV2 } from '@/lib/finance/pricing/contracts'
+
+export interface UsePricingSimulationOptions {
+
+  /** Milisegundos de debounce antes de disparar el fetch (default 500ms) */
+  debounceMs?: number
+
+  /** Endpoint a consumir — default `/api/finance/quotes/pricing/simulate` */
+  endpoint?: string
+
+  /** Si false, no dispara fetch (útil mientras el usuario completa el input mínimo) */
+  enabled?: boolean
+}
+
+export interface UsePricingSimulationResult {
+  output: PricingEngineOutputV2 | null
+  loading: boolean
+  error: string | null
+
+  /** Última vez que el fetch terminó (exitoso o no). Null si nunca ha corrido. */
+  lastUpdatedAt: number | null
+}
+
+/**
+ * Hook que debouncea un input del engine v2 y llama al endpoint `simulate` para
+ * obtener el output del engine. Usa AbortController para cancelar requests en vuelo
+ * cuando el input cambia. Retorna `loading` para skeletons y `error` si la simulación falla.
+ *
+ * Si `enabled === false`, retorna el último valor conocido sin disparar fetch.
+ */
+export const usePricingSimulation = (
+  input: PricingEngineInputV2 | null,
+  options: UsePricingSimulationOptions = {}
+): UsePricingSimulationResult => {
+  const { debounceMs = 500, endpoint = '/api/finance/quotes/pricing/simulate', enabled = true } = options
+
+  const [output, setOutput] = useState<PricingEngineOutputV2 | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const serializedInput = input ? JSON.stringify(input) : null
+
+  useEffect(() => {
+    if (!enabled || !input || input.lines.length === 0) {
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      if (abortRef.current) abortRef.current.abort()
+      const controller = new AbortController()
+
+      abortRef.current = controller
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(input),
+          signal: controller.signal
+        })
+
+        if (!response.ok) {
+          const body = (await response.json().catch(() => ({}))) as { error?: string }
+
+          throw new Error(body.error ?? `Simulate failed: HTTP ${response.status}`)
+        }
+
+        const result = (await response.json()) as PricingEngineOutputV2
+
+        if (!controller.signal.aborted) {
+          setOutput(result)
+          setLastUpdatedAt(Date.now())
+        }
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : 'Simulate failed.')
+        setLastUpdatedAt(Date.now())
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }, debounceMs)
+
+    return () => {
+      clearTimeout(timer)
+      if (abortRef.current) abortRef.current.abort()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serializedInput, enabled, debounceMs, endpoint])
+
+  return { output, loading, error, lastUpdatedAt }
+}
+
+export default usePricingSimulation

--- a/src/lib/tenant/authorization.ts
+++ b/src/lib/tenant/authorization.ts
@@ -70,6 +70,20 @@ export const canAccessBankTreasury = (tenant: TenantContext) =>
   hasRoleCode(tenant, ROLE_CODES.FINANCE_ADMIN) ||
   hasRoleCode(tenant, ROLE_CODES.FINANCE_ANALYST)
 
+/**
+ * Gates visibility of the internal cost stack in the commercial pricing builder
+ * (TASK-464e §Permission gating rule). Hidden to account/ops/client roles so that
+ * bill rates + margins remain visible but hourly cost breakdown + markup stays internal.
+ *
+ * Aligned with canAccessBankTreasury (finance admin + finance analyst + efeonce admin).
+ * Reconciled from TASK-464e spec which used `finance_manager` (not a runtime role code
+ * in this repo) and `finance` (not a role code, it's a route group).
+ */
+export const canViewCostStack = (tenant: TenantContext) =>
+  hasRoleCode(tenant, ROLE_CODES.EFEONCE_ADMIN) ||
+  hasRoleCode(tenant, ROLE_CODES.FINANCE_ADMIN) ||
+  hasRoleCode(tenant, ROLE_CODES.FINANCE_ANALYST)
+
 export const canAccessPeopleModule = (tenant: TenantContext) =>
   hasRouteGroup(tenant, 'people') ||
   hasRoleCode(tenant, ROLE_CODES.EFEONCE_ADMIN) ||

--- a/src/views/greenhouse/finance/workspace/AddonSuggestionsPanel.tsx
+++ b/src/views/greenhouse/finance/workspace/AddonSuggestionsPanel.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import Box from '@mui/material/Box'
+import Checkbox from '@mui/material/Checkbox'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+import EmptyState from '@/components/greenhouse/EmptyState'
+
+import type { PricingAddonOutputV2, PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
+
+import { formatOutputMoney } from './QuoteTotalsFooter'
+
+export interface AddonSuggestionsPanelProps {
+
+  /** Addons auto-resueltos por el engine v2 (output.addons) */
+  suggestions: PricingAddonOutputV2[]
+
+  /** SKUs actualmente incluidos en la quote (active) */
+  includedSkus: string[]
+
+  /** Toggle de un addon: incluirlo o excluirlo */
+  onToggle: (sku: string, include: boolean) => void
+
+  /** Moneda output de la quote */
+  outputCurrency: PricingOutputCurrency
+  loading?: boolean
+}
+
+/**
+ * Panel sticky-right con los addons auto-resueltos por el engine v2. El usuario
+ * puede toggle on/off cada addon — el parent decide si reenvía el input al engine
+ * con los includedSkus actualizados (marcándolos como línea overhead_addon
+ * explícita vs dejar que el engine los auto-resuelva).
+ */
+const AddonSuggestionsPanel = ({
+  suggestions,
+  includedSkus,
+  onToggle,
+  outputCurrency,
+  loading = false
+}: AddonSuggestionsPanelProps) => {
+  const includedSet = new Set(includedSkus)
+
+  return (
+    <Box
+      component='aside'
+      aria-label='Addons sugeridos'
+      sx={theme => ({
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        p: 2,
+        minWidth: 280
+      })}
+    >
+      <Typography variant='subtitle2' sx={{ mb: 1 }}>
+        Addons sugeridos
+      </Typography>
+
+      {loading ? (
+        <Typography variant='body2' color='text.secondary'>
+          Calculando addons aplicables...
+        </Typography>
+      ) : suggestions.length === 0 ? (
+        <EmptyState
+          icon='tabler-checkbox'
+          title='Ningún addon sugerido'
+          description='El engine no encontró addons aplicables para este contexto.'
+        />
+      ) : (
+        <Stack spacing={1.5} divider={<Divider flexItem />}>
+          {suggestions.map(suggestion => {
+            const isIncluded = includedSet.has(suggestion.sku)
+
+            return (
+              <Box key={suggestion.sku}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={isIncluded}
+                      onChange={event => onToggle(suggestion.sku, event.target.checked)}
+                      inputProps={{ 'aria-label': `Incluir ${suggestion.addonName}` }}
+                    />
+                  }
+                  label={
+                    <Stack spacing={0.25} sx={{ flex: 1 }}>
+                      <Stack direction='row' spacing={1} alignItems='center'>
+                        <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                          {suggestion.addonName}
+                        </Typography>
+                        <Chip
+                          size='small'
+                          label={suggestion.visibleToClient ? 'Cliente' : 'Interno'}
+                          color={suggestion.visibleToClient ? 'primary' : 'default'}
+                          sx={{ height: 18, fontSize: '0.65rem' }}
+                        />
+                      </Stack>
+                      <Typography variant='caption' color='text.secondary'>
+                        {suggestion.appliedReason}
+                      </Typography>
+                      <Typography variant='caption' sx={{ fontFamily: 'monospace' }}>
+                        {formatOutputMoney(suggestion.amountOutputCurrency, outputCurrency)}
+                        {' · '}
+                        {formatOutputMoney(suggestion.amountUsd, 'USD')}
+                      </Typography>
+                    </Stack>
+                  }
+                  sx={{ alignItems: 'flex-start', m: 0, gap: 1, '& .MuiFormControlLabel-label': { flex: 1 } }}
+                />
+              </Box>
+            )
+          })}
+        </Stack>
+      )}
+    </Box>
+  )
+}
+
+export default AddonSuggestionsPanel

--- a/src/views/greenhouse/finance/workspace/QuoteBuilderActions.tsx
+++ b/src/views/greenhouse/finance/workspace/QuoteBuilderActions.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+import CustomTextField from '@core/components/mui/TextField'
+
+import type { CommercialModelCode } from '@/lib/commercial/pricing-governance-types'
+import type { PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
+import { GH_PRICING } from '@/config/greenhouse-nomenclature'
+
+import CurrencySwitcher from '@/components/greenhouse/pricing/CurrencySwitcher'
+
+export interface QuoteBuilderState {
+  businessLineCode: string | null
+  commercialModel: CommercialModelCode
+  countryFactorCode: string
+  outputCurrency: PricingOutputCurrency
+  contractDurationMonths: number | null
+  validUntil: string | null
+  description: string
+}
+
+export interface QuoteBuilderActionsOptions {
+  businessLines: Array<{ code: string; label: string }>
+  commercialModels: Array<{ code: CommercialModelCode; label: string; multiplierPct: number }>
+  countryFactors: Array<{ code: string; label: string; factor: number }>
+}
+
+export interface QuoteBuilderActionsProps {
+  state: QuoteBuilderState
+  onChange: (patch: Partial<QuoteBuilderState>) => void
+  options: QuoteBuilderActionsOptions
+  disabled?: boolean
+}
+
+const formatMultiplier = (pct: number): string => {
+  const signed = pct >= 0 ? `+${pct}` : `${pct}`
+
+  return `${signed}%`
+}
+
+const formatFactor = (factor: number): string => factor.toFixed(2)
+
+/**
+ * Sidebar del quote builder con los selectores de contexto del engine v2
+ * (businessLine, commercialModel, countryFactor, outputCurrency) + campos
+ * drawer-level (contract duration, valid until, description).
+ *
+ * State controlado: parent mantiene `QuoteBuilderState`, aquí solo se renderiza
+ * y se emite `onChange` con patches parciales.
+ */
+const QuoteBuilderActions = ({ state, onChange, options, disabled = false }: QuoteBuilderActionsProps) => {
+  const selectedCommercialModel = options.commercialModels.find(m => m.code === state.commercialModel)
+  const selectedCountryFactor = options.countryFactors.find(c => c.code === state.countryFactorCode)
+
+  return (
+    <Stack spacing={3} component='aside' aria-label='Contexto de la cotización'>
+      <CustomTextField
+        select
+        fullWidth
+        size='small'
+        label='Business line'
+        value={state.businessLineCode ?? ''}
+        disabled={disabled}
+        onChange={event => {
+          const value = event.target.value
+
+          onChange({ businessLineCode: value === '' ? null : value })
+        }}
+      >
+        <MenuItem value=''>Sin BL</MenuItem>
+        {options.businessLines.map(bl => (
+          <MenuItem key={bl.code} value={bl.code}>
+            {bl.label}
+          </MenuItem>
+        ))}
+      </CustomTextField>
+
+      <Box>
+        <CustomTextField
+          select
+          fullWidth
+          size='small'
+          label={GH_PRICING.commercialModelLabel}
+          value={state.commercialModel}
+          disabled={disabled}
+          onChange={event => onChange({ commercialModel: event.target.value as CommercialModelCode })}
+        >
+          {options.commercialModels.map(model => (
+            <MenuItem key={model.code} value={model.code}>
+              {model.label}
+            </MenuItem>
+          ))}
+        </CustomTextField>
+        {selectedCommercialModel ? (
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 0.5 }}>
+            {selectedCommercialModel.label} · {formatMultiplier(selectedCommercialModel.multiplierPct)} sobre tarifa base
+          </Typography>
+        ) : null}
+      </Box>
+
+      <Box>
+        <CustomTextField
+          select
+          fullWidth
+          size='small'
+          label={GH_PRICING.countryFactorLabel}
+          value={state.countryFactorCode}
+          disabled={disabled}
+          onChange={event => onChange({ countryFactorCode: event.target.value })}
+        >
+          {options.countryFactors.map(factor => (
+            <MenuItem key={factor.code} value={factor.code}>
+              {factor.label}
+            </MenuItem>
+          ))}
+        </CustomTextField>
+        {selectedCountryFactor ? (
+          <Stack direction='row' spacing={1} alignItems='center' sx={{ mt: 0.5 }}>
+            <Typography variant='caption' color='text.secondary'>
+              {selectedCountryFactor.label}
+            </Typography>
+            <Chip
+              size='small'
+              label={`factor ${formatFactor(selectedCountryFactor.factor)}`}
+              sx={{ height: 18, fontSize: '0.65rem' }}
+            />
+          </Stack>
+        ) : null}
+      </Box>
+
+      <CurrencySwitcher
+        value={state.outputCurrency}
+        onChange={value => onChange({ outputCurrency: value })}
+        disabled={disabled}
+        size='small'
+        fullWidth
+      />
+
+      <CustomTextField
+        fullWidth
+        size='small'
+        type='number'
+        label='Duración del contrato (meses)'
+        value={state.contractDurationMonths ?? ''}
+        disabled={disabled}
+        onChange={event => {
+          const parsed = Number.parseInt(event.target.value, 10)
+
+          onChange({ contractDurationMonths: Number.isFinite(parsed) ? parsed : null })
+        }}
+        inputProps={{ min: 1, max: 120, step: 1 }}
+        helperText='Requerido para retainer o híbrido'
+      />
+
+      <CustomTextField
+        fullWidth
+        size='small'
+        type='date'
+        label='Válida hasta'
+        value={state.validUntil ?? ''}
+        disabled={disabled}
+        onChange={event => onChange({ validUntil: event.target.value || null })}
+        InputLabelProps={{ shrink: true }}
+      />
+
+      <CustomTextField
+        fullWidth
+        multiline
+        minRows={3}
+        size='small'
+        label='Descripción'
+        value={state.description}
+        disabled={disabled}
+        onChange={event => onChange({ description: event.target.value })}
+        placeholder='Alcance del servicio, contexto, notas internas...'
+      />
+    </Stack>
+  )
+}
+
+export default QuoteBuilderActions

--- a/src/views/greenhouse/finance/workspace/QuoteCreateDrawer.tsx
+++ b/src/views/greenhouse/finance/workspace/QuoteCreateDrawer.tsx
@@ -26,7 +26,12 @@ import CustomChip from '@core/components/mui/Chip'
 import CustomTextField from '@core/components/mui/TextField'
 
 type PricingModel = 'staff_aug' | 'retainer' | 'project'
-type Currency = 'CLP' | 'USD' | 'CLF'
+
+// Alineado con PricingOutputCurrency del engine v2 (TASK-464d).
+// Antes: solo CLP/USD/CLF; extendido a 6 monedas LatAm para consistency con
+// el engine y con CurrencySwitcher primitive (TASK-464e).
+type Currency = 'CLP' | 'USD' | 'CLF' | 'COP' | 'MXN' | 'PEN'
+
 type BillingFrequency = 'monthly' | 'milestone' | 'one_time'
 type LineUnit = 'hour' | 'month' | 'unit' | 'project'
 
@@ -88,7 +93,10 @@ const PRICING_MODEL_OPTIONS: Array<{ value: PricingModel; label: string }> = [
 const CURRENCY_OPTIONS: Array<{ value: Currency; label: string }> = [
   { value: 'CLP', label: 'CLP · Peso chileno' },
   { value: 'USD', label: 'USD · Dólar' },
-  { value: 'CLF', label: 'CLF · UF' }
+  { value: 'CLF', label: 'CLF · UF' },
+  { value: 'COP', label: 'COP · Peso colombiano' },
+  { value: 'MXN', label: 'MXN · Peso mexicano' },
+  { value: 'PEN', label: 'PEN · Sol peruano' }
 ]
 
 const BILLING_FREQUENCY_OPTIONS: Array<{ value: BillingFrequency; label: string }> = [
@@ -105,7 +113,7 @@ const UNIT_OPTIONS: Array<{ value: LineUnit; label: string }> = [
 ]
 
 const coerceCurrency = (value: string): Currency => {
-  if (value === 'USD' || value === 'CLF') return value
+  if (value === 'USD' || value === 'CLF' || value === 'COP' || value === 'MXN' || value === 'PEN') return value
 
   return 'CLP'
 }

--- a/src/views/greenhouse/finance/workspace/QuoteCreateDrawer.tsx
+++ b/src/views/greenhouse/finance/workspace/QuoteCreateDrawer.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { useSession } from 'next-auth/react'
+
 import Alert from '@mui/material/Alert'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
@@ -25,12 +27,23 @@ import Typography from '@mui/material/Typography'
 import CustomChip from '@core/components/mui/Chip'
 import CustomTextField from '@core/components/mui/TextField'
 
+import type { CommercialModelCode } from '@/lib/commercial/pricing-governance-types'
+import type { PricingEngineInputV2, PricingLineInputV2, PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
+import { ROLE_CODES } from '@/config/role-codes'
+
+import usePricingSimulation from '@/hooks/usePricingSimulation'
+
+import QuoteBuilderActions, {
+  type QuoteBuilderActionsOptions,
+  type QuoteBuilderState
+} from './QuoteBuilderActions'
+import QuoteTotalsFooter from './QuoteTotalsFooter'
+import AddonSuggestionsPanel from './AddonSuggestionsPanel'
+
 type PricingModel = 'staff_aug' | 'retainer' | 'project'
 
 // Alineado con PricingOutputCurrency del engine v2 (TASK-464d).
-// Antes: solo CLP/USD/CLF; extendido a 6 monedas LatAm para consistency con
-// el engine y con CurrencySwitcher primitive (TASK-464e).
-type Currency = 'CLP' | 'USD' | 'CLF' | 'COP' | 'MXN' | 'PEN'
+type Currency = PricingOutputCurrency
 
 type BillingFrequency = 'monthly' | 'milestone' | 'one_time'
 type LineUnit = 'hour' | 'month' | 'unit' | 'project'
@@ -90,15 +103,6 @@ const PRICING_MODEL_OPTIONS: Array<{ value: PricingModel; label: string }> = [
   { value: 'project', label: 'Proyecto cerrado' }
 ]
 
-const CURRENCY_OPTIONS: Array<{ value: Currency; label: string }> = [
-  { value: 'CLP', label: 'CLP · Peso chileno' },
-  { value: 'USD', label: 'USD · Dólar' },
-  { value: 'CLF', label: 'CLF · UF' },
-  { value: 'COP', label: 'COP · Peso colombiano' },
-  { value: 'MXN', label: 'MXN · Peso mexicano' },
-  { value: 'PEN', label: 'PEN · Sol peruano' }
-]
-
 const BILLING_FREQUENCY_OPTIONS: Array<{ value: BillingFrequency; label: string }> = [
   { value: 'monthly', label: 'Mensual' },
   { value: 'milestone', label: 'Por hito' },
@@ -110,6 +114,28 @@ const UNIT_OPTIONS: Array<{ value: LineUnit; label: string }> = [
   { value: 'month', label: 'Mes' },
   { value: 'unit', label: 'Unidad' },
   { value: 'project', label: 'Proyecto' }
+]
+
+const DEFAULT_COMMERCIAL_MODELS: QuoteBuilderActionsOptions['commercialModels'] = [
+  { code: 'on_going', label: 'On-Going', multiplierPct: 0 },
+  { code: 'on_demand', label: 'On-Demand', multiplierPct: 15 },
+  { code: 'hybrid', label: 'Híbrido', multiplierPct: 10 },
+  { code: 'license_consulting', label: 'Licencia / Consultoría', multiplierPct: 5 }
+]
+
+const DEFAULT_COUNTRY_FACTORS: QuoteBuilderActionsOptions['countryFactors'] = [
+  { code: 'chile_corporate', label: 'Chile Corporate', factor: 1.0 },
+  { code: 'chile_pyme', label: 'Chile PYME', factor: 0.85 },
+  { code: 'colombia_latam', label: 'Colombia / PYME LATAM', factor: 0.7 },
+  { code: 'international_usd', label: 'Internacional USD', factor: 1.15 },
+  { code: 'licitacion_publica', label: 'Licitación Pública', factor: 0.9 },
+  { code: 'cliente_estrategico', label: 'Cliente Estratégico', factor: 1.0 }
+]
+
+const FINANCE_ROLE_CODES: readonly string[] = [
+  ROLE_CODES.EFEONCE_ADMIN,
+  ROLE_CODES.FINANCE_ADMIN,
+  ROLE_CODES.FINANCE_ANALYST
 ]
 
 const coerceCurrency = (value: string): Currency => {
@@ -131,6 +157,36 @@ const emptyLineItem = (): QuoteCreateLineItem => ({
   unit: 'hour'
 })
 
+const todayIso = (): string => new Date().toISOString().slice(0, 10)
+
+const buildPricingInput = (
+  builderState: QuoteBuilderState,
+  currency: Currency,
+  lineItems: QuoteCreateLineItem[]
+): PricingEngineInputV2 | null => {
+  const lines: PricingLineInputV2[] = lineItems
+    .filter(item => item.label.trim().length > 0 && item.quantity > 0 && item.unitPrice > 0)
+    .map(item => ({
+      lineType: 'direct_cost' as const,
+      label: item.label.trim(),
+      amount: item.unitPrice,
+      currency,
+      quantity: item.quantity
+    }))
+
+  if (lines.length === 0) return null
+
+  return {
+    businessLineCode: builderState.businessLineCode,
+    commercialModel: builderState.commercialModel,
+    countryFactorCode: builderState.countryFactorCode,
+    outputCurrency: builderState.outputCurrency,
+    quoteDate: todayIso(),
+    lines,
+    autoResolveAddons: true
+  }
+}
+
 const QuoteCreateDrawer = ({
   open,
   submitting,
@@ -140,33 +196,119 @@ const QuoteCreateDrawer = ({
   onClose,
   onSubmit
 }: QuoteCreateDrawerProps) => {
+  const { data: session } = useSession()
+
+  const canSeeCostStack = useMemo(() => {
+    const roles = session?.user?.roleCodes ?? []
+
+    return FINANCE_ROLE_CODES.some(code => roles.includes(code))
+  }, [session?.user?.roleCodes])
+
   const [mode, setMode] = useState<CreateMode>('scratch')
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null)
   const [organizationId, setOrganizationId] = useState<string | null>(null)
-  const [description, setDescription] = useState('')
   const [pricingModel, setPricingModel] = useState<PricingModel>('project')
-  const [currency, setCurrency] = useState<Currency>('CLP')
   const [billingFrequency, setBillingFrequency] = useState<BillingFrequency>('monthly')
-  const [contractDurationMonths, setContractDurationMonths] = useState<number | ''>('')
-  const [validUntil, setValidUntil] = useState('')
   const [lineItems, setLineItems] = useState<QuoteCreateLineItem[]>([emptyLineItem()])
   const [localError, setLocalError] = useState<string | null>(null)
+
+  const [builderState, setBuilderState] = useState<QuoteBuilderState>({
+    businessLineCode: null,
+    commercialModel: 'on_going',
+    countryFactorCode: 'chile_corporate',
+    outputCurrency: 'CLP',
+    contractDurationMonths: null,
+    validUntil: null,
+    description: ''
+  })
+
+  const [builderOptions, setBuilderOptions] = useState<QuoteBuilderActionsOptions>({
+    businessLines: [],
+    commercialModels: DEFAULT_COMMERCIAL_MODELS,
+    countryFactors: DEFAULT_COUNTRY_FACTORS
+  })
+
+  const [excludedAddons, setExcludedAddons] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     if (!open) {
       setMode('scratch')
       setSelectedTemplateId(null)
       setOrganizationId(null)
-      setDescription('')
       setPricingModel('project')
-      setCurrency('CLP')
       setBillingFrequency('monthly')
-      setContractDurationMonths('')
-      setValidUntil('')
       setLineItems([emptyLineItem()])
       setLocalError(null)
+      setExcludedAddons(new Set())
+      setBuilderState({
+        businessLineCode: null,
+        commercialModel: 'on_going',
+        countryFactorCode: 'chile_corporate',
+        outputCurrency: 'CLP',
+        contractDurationMonths: null,
+        validUntil: null,
+        description: ''
+      })
     }
   }, [open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const controller = new AbortController()
+
+    ;(async () => {
+      try {
+        const res = await fetch('/api/finance/quotes/pricing/config', { signal: controller.signal })
+
+        if (!res.ok) return
+
+        const payload = (await res.json()) as {
+          catalog?: {
+            commercialModelMultipliers?: Array<{ modelCode: CommercialModelCode; modelLabel: string; multiplierPct: number }>
+            countryPricingFactors?: Array<{ factorCode: string; factorLabel: string; factorOpt: number }>
+          }
+        }
+
+        const commercialModels = payload.catalog?.commercialModelMultipliers?.map(m => ({
+          code: m.modelCode,
+          label: m.modelLabel,
+          multiplierPct: Number(m.multiplierPct)
+        }))
+
+        const countryFactors = payload.catalog?.countryPricingFactors?.map(f => ({
+          code: f.factorCode,
+          label: f.factorLabel,
+          factor: Number(f.factorOpt)
+        }))
+
+        setBuilderOptions(prev => ({
+          businessLines: prev.businessLines,
+          commercialModels: commercialModels && commercialModels.length > 0 ? commercialModels : prev.commercialModels,
+          countryFactors: countryFactors && countryFactors.length > 0 ? countryFactors : prev.countryFactors
+        }))
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+      }
+    })()
+
+    return () => controller.abort()
+  }, [open])
+
+  const handleBuilderChange = useCallback((patch: Partial<QuoteBuilderState>) => {
+    setBuilderState(prev => ({ ...prev, ...patch }))
+  }, [])
+
+  const pricingInput = useMemo(
+    () => (open ? buildPricingInput(builderState, builderState.outputCurrency, lineItems) : null),
+    [open, builderState, lineItems]
+  )
+
+  const {
+    output: simulation,
+    loading: simulating,
+    error: simulationError
+  } = usePricingSimulation(pricingInput, { enabled: open && mode === 'scratch' })
 
   const selectedTemplate = useMemo(
     () => (selectedTemplateId ? templates.find(t => t.templateId === selectedTemplateId) ?? null : null),
@@ -200,9 +342,13 @@ const QuoteCreateDrawer = ({
     if (!template) return
 
     setPricingModel(template.pricingModel)
-    setCurrency(coerceCurrency(template.defaults.currency))
     setBillingFrequency(coerceBillingFrequency(template.defaults.billingFrequency))
-    setContractDurationMonths(template.defaults.contractDurationMonths ?? '')
+    setBuilderState(prev => ({
+      ...prev,
+      outputCurrency: coerceCurrency(template.defaults.currency),
+      contractDurationMonths: template.defaults.contractDurationMonths ?? prev.contractDurationMonths,
+      businessLineCode: template.businessLineCode ?? prev.businessLineCode
+    }))
   }, [])
 
   const updateLineItem = useCallback((index: number, patch: Partial<QuoteCreateLineItem>) => {
@@ -223,9 +369,25 @@ const QuoteCreateDrawer = ({
     setLineItems(prev => prev.filter((_, i) => i !== index))
   }, [])
 
+  const handleAddonToggle = useCallback((sku: string, include: boolean) => {
+    setExcludedAddons(prev => {
+      const next = new Set(prev)
+
+      if (include) next.delete(sku)
+      else next.add(sku)
+
+      return next
+    })
+  }, [])
+
+  const includedAddonSkus = useMemo(
+    () => (simulation?.addons ?? []).map(a => a.sku).filter(sku => !excludedAddons.has(sku)),
+    [simulation?.addons, excludedAddons]
+  )
+
   const validate = useCallback((): string | null => {
     if (!organizationId) return 'Selecciona un espacio para la cotización.'
-    if (description.trim().length === 0) return 'Agrega una descripción breve del alcance.'
+    if (builderState.description.trim().length === 0) return 'Agrega una descripción breve del alcance.'
 
     if (mode === 'template' && !selectedTemplateId) {
       return 'Selecciona un template para continuar.'
@@ -240,7 +402,7 @@ const QuoteCreateDrawer = ({
     }
 
     return null
-  }, [description, lineItems, mode, organizationId, selectedTemplateId])
+  }, [builderState.description, lineItems, mode, organizationId, selectedTemplateId])
 
   const handleSubmit = useCallback(async () => {
     const validation = validate()
@@ -256,13 +418,12 @@ const QuoteCreateDrawer = ({
     const payload = {
       templateId: mode === 'template' ? selectedTemplateId : null,
       organizationId,
-      description: description.trim(),
+      description: builderState.description.trim(),
       pricingModel,
-      currency,
+      currency: builderState.outputCurrency,
       billingFrequency,
-      contractDurationMonths:
-        contractDurationMonths === '' ? null : Number.isFinite(Number(contractDurationMonths)) ? Number(contractDurationMonths) : null,
-      validUntil: validUntil.trim() ? validUntil : null,
+      contractDurationMonths: builderState.contractDurationMonths,
+      validUntil: builderState.validUntil,
       lineItems:
         mode === 'scratch'
           ? lineItems.map(item => ({
@@ -277,17 +438,17 @@ const QuoteCreateDrawer = ({
     await onSubmit(payload)
   }, [
     billingFrequency,
-    contractDurationMonths,
-    currency,
-    description,
+    builderState.contractDurationMonths,
+    builderState.description,
+    builderState.outputCurrency,
+    builderState.validUntil,
     lineItems,
     mode,
     onSubmit,
     organizationId,
     pricingModel,
     selectedTemplateId,
-    validate,
-    validUntil
+    validate
   ])
 
   return (
@@ -295,7 +456,7 @@ const QuoteCreateDrawer = ({
       anchor='right'
       open={open}
       onClose={submitting ? undefined : onClose}
-      PaperProps={{ sx: { width: { xs: '100%', sm: 560 } } }}
+      PaperProps={{ sx: { width: { xs: '100%', sm: 720, md: 880 } } }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', p: 4 }}>
         <Box>
@@ -310,333 +471,316 @@ const QuoteCreateDrawer = ({
       </Box>
       <Divider />
 
-      <Stack spacing={3} sx={{ p: 4, overflowY: 'auto', flex: 1 }}>
-        <Box>
-          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mb: 1 }}>
-            Punto de partida
-          </Typography>
-          <ToggleButtonGroup
-            value={mode}
-            exclusive
-            onChange={handleModeChange}
-            fullWidth
-            size='small'
-            aria-label='Modo de creación de la cotización'
-          >
-            <ToggleButton value='scratch' aria-label='Crear desde cero'>
-              <i className='tabler-pencil-plus' style={{ marginInlineEnd: 8 }} />
-              Desde cero
-            </ToggleButton>
-            <ToggleButton value='template' aria-label='Crear desde template'>
-              <i className='tabler-template' style={{ marginInlineEnd: 8 }} />
-              Desde template
-            </ToggleButton>
-          </ToggleButtonGroup>
-          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 1 }}>
-            {mode === 'scratch'
-              ? 'Define los ítems manualmente. Ideal para alcances únicos o muy personalizados.'
-              : 'Hereda ítems, términos y modelo desde un template aprobado. Puedes ajustarlos después.'}
-          </Typography>
-        </Box>
+      <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        {/* Columna izquierda: form principal */}
+        <Stack spacing={3} sx={{ p: 4, overflowY: 'auto', flex: 1, minWidth: 0 }}>
+          <Box>
+            <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mb: 1 }}>
+              Punto de partida
+            </Typography>
+            <ToggleButtonGroup
+              value={mode}
+              exclusive
+              onChange={handleModeChange}
+              fullWidth
+              size='small'
+              aria-label='Modo de creación de la cotización'
+            >
+              <ToggleButton value='scratch' aria-label='Crear desde cero'>
+                <i className='tabler-pencil-plus' style={{ marginInlineEnd: 8 }} />
+                Desde cero
+              </ToggleButton>
+              <ToggleButton value='template' aria-label='Crear desde template'>
+                <i className='tabler-template' style={{ marginInlineEnd: 8 }} />
+                Desde template
+              </ToggleButton>
+            </ToggleButtonGroup>
+            <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 1 }}>
+              {mode === 'scratch'
+                ? 'Define los ítems manualmente. Ideal para alcances únicos o muy personalizados.'
+                : 'Hereda ítems, términos y modelo desde un template aprobado. Puedes ajustarlos después.'}
+            </Typography>
+          </Box>
 
-        {mode === 'template' && (
+          {mode === 'template' && (
+            <Autocomplete
+              size='small'
+              options={templates}
+              value={selectedTemplate}
+              onChange={(_event, value) => applyTemplate(value)}
+              getOptionLabel={option => `${option.templateCode} · ${option.templateName}`}
+              disabled={submitting}
+              renderOption={(props, option) => (
+                <li {...props} key={option.templateId}>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                      {option.templateName}
+                    </Typography>
+                    <Typography variant='caption' color='text.secondary'>
+                      {option.templateCode}
+                      {option.businessLineCode ? ` · ${option.businessLineCode}` : ''}
+                      {option.usageCount > 0 ? ` · ${option.usageCount} usos` : ''}
+                    </Typography>
+                  </Box>
+                </li>
+              )}
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  size='small'
+                  label='Template'
+                  placeholder='Busca un template aprobado'
+                  aria-label='Template de cotización'
+                />
+              )}
+            />
+          )}
+
+          {mode === 'template' && !selectedTemplate && templates.length === 0 && (
+            <Alert severity='info'>
+              Aún no hay templates disponibles. Guarda una cotización como template para reutilizarla después.
+            </Alert>
+          )}
+
+          {mode === 'template' && selectedTemplate && (
+            <Box sx={{ p: 2, bgcolor: 'background.default', borderRadius: 1 }}>
+              <Stack direction='row' spacing={1} alignItems='center' flexWrap='wrap'>
+                <CustomChip round='true' size='small' variant='tonal' color='primary' label={selectedTemplate.pricingModel} />
+                {selectedTemplate.businessLineCode && (
+                  <CustomChip
+                    round='true'
+                    size='small'
+                    variant='tonal'
+                    color='info'
+                    label={selectedTemplate.businessLineCode}
+                  />
+                )}
+                <Typography variant='caption' color='text.secondary'>
+                  {selectedTemplate.usageCount === 1
+                    ? '1 cotización creada desde este template'
+                    : `${selectedTemplate.usageCount} cotizaciones creadas desde este template`}
+                </Typography>
+              </Stack>
+              <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 1 }}>
+                Los ítems del template se crearán automáticamente al guardar.
+              </Typography>
+            </Box>
+          )}
+
           <Autocomplete
             size='small'
-            options={templates}
-            value={selectedTemplate}
-            onChange={(_event, value) => applyTemplate(value)}
-            getOptionLabel={option => `${option.templateCode} · ${option.templateName}`}
+            options={organizations}
+            value={selectedOrganization}
+            onChange={(_event, value) => setOrganizationId(value ? value.organizationId : null)}
+            getOptionLabel={option => option.organizationName}
             disabled={submitting}
-            renderOption={(props, option) => (
-              <li {...props} key={option.templateId}>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
-                    {option.templateName}
-                  </Typography>
-                  <Typography variant='caption' color='text.secondary'>
-                    {option.templateCode}
-                    {option.businessLineCode ? ` · ${option.businessLineCode}` : ''}
-                    {option.usageCount > 0 ? ` · ${option.usageCount} usos` : ''}
-                  </Typography>
-                </Box>
-              </li>
-            )}
             renderInput={params => (
               <TextField
                 {...params}
                 size='small'
-                label='Template'
-                placeholder='Busca un template aprobado'
-                aria-label='Template de cotización'
+                label='Espacio'
+                required
+                placeholder='Busca por nombre'
+                aria-label='Espacio de la cotización'
               />
             )}
           />
-        )}
 
-        {mode === 'template' && !selectedTemplate && templates.length === 0 && (
-          <Alert severity='info'>
-            Aún no hay templates disponibles. Guarda una cotización como template para reutilizarla después.
-          </Alert>
-        )}
-
-        {mode === 'template' && selectedTemplate && (
-          <Box sx={{ p: 2, bgcolor: 'background.default', borderRadius: 1 }}>
-            <Stack direction='row' spacing={1} alignItems='center' flexWrap='wrap'>
-              <CustomChip round='true' size='small' variant='tonal' color='primary' label={selectedTemplate.pricingModel} />
-              {selectedTemplate.businessLineCode && (
-                <CustomChip
-                  round='true'
-                  size='small'
-                  variant='tonal'
-                  color='info'
-                  label={selectedTemplate.businessLineCode}
-                />
-              )}
-              <Typography variant='caption' color='text.secondary'>
-                {selectedTemplate.usageCount === 1
-                  ? '1 cotización creada desde este template'
-                  : `${selectedTemplate.usageCount} cotizaciones creadas desde este template`}
-              </Typography>
-            </Stack>
-            <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 1 }}>
-              Los ítems del template se crearán automáticamente al guardar.
-            </Typography>
-          </Box>
-        )}
-
-        <Autocomplete
-          size='small'
-          options={organizations}
-          value={selectedOrganization}
-          onChange={(_event, value) => setOrganizationId(value ? value.organizationId : null)}
-          getOptionLabel={option => option.organizationName}
-          disabled={submitting}
-          renderInput={params => (
-            <TextField
-              {...params}
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <CustomTextField
+              select
+              fullWidth
               size='small'
-              label='Espacio'
-              required
-              placeholder='Busca por nombre'
-              aria-label='Espacio de la cotización'
+              label='Modelo de pricing'
+              value={pricingModel}
+              onChange={event => setPricingModel(event.target.value as PricingModel)}
+              disabled={submitting}
+            >
+              {PRICING_MODEL_OPTIONS.map(option => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </CustomTextField>
+            <CustomTextField
+              select
+              fullWidth
+              size='small'
+              label='Frecuencia de facturación'
+              value={billingFrequency}
+              onChange={event => setBillingFrequency(event.target.value as BillingFrequency)}
+              disabled={submitting}
+            >
+              {BILLING_FREQUENCY_OPTIONS.map(option => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </CustomTextField>
+          </Stack>
+
+          {mode === 'scratch' && (
+            <Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                <Typography variant='subtitle2'>Ítems de la cotización</Typography>
+                <Button
+                  size='small'
+                  variant='outlined'
+                  startIcon={<i className='tabler-plus' />}
+                  onClick={handleAddLine}
+                  disabled={submitting}
+                >
+                  Agregar ítem
+                </Button>
+              </Box>
+              {lineItems.length === 0 ? (
+                <Alert severity='info' role='status'>
+                  Agrega al menos un ítem para estimar el precio y la salud de margen.
+                </Alert>
+              ) : (
+                <Box sx={{ overflowX: 'auto' }}>
+                  <Table size='small'>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell sx={{ minWidth: 180 }}>Ítem</TableCell>
+                        <TableCell sx={{ minWidth: 80 }} align='right'>Cantidad</TableCell>
+                        <TableCell sx={{ minWidth: 100 }}>Unidad</TableCell>
+                        <TableCell sx={{ minWidth: 120 }} align='right'>Precio unitario</TableCell>
+                        <TableCell sx={{ minWidth: 56 }} />
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {lineItems.map((line, index) => (
+                        <TableRow key={`draft-line-${index}`}>
+                          <TableCell>
+                            <CustomTextField
+                              size='small'
+                              fullWidth
+                              placeholder='Ej. Horas de desarrollo'
+                              value={line.label}
+                              onChange={event => updateLineItem(index, { label: event.target.value })}
+                              disabled={submitting}
+                              aria-label={`Etiqueta del ítem ${index + 1}`}
+                            />
+                          </TableCell>
+                          <TableCell align='right'>
+                            <CustomTextField
+                              size='small'
+                              type='number'
+                              value={line.quantity}
+                              onChange={event => {
+                                const raw = event.target.value
+                                const next = raw === '' ? 0 : Number(raw)
+
+                                updateLineItem(index, { quantity: Number.isFinite(next) ? next : 0 })
+                              }}
+                              inputProps={{ min: 0, step: 'any' }}
+                              disabled={submitting}
+                              aria-label={`Cantidad del ítem ${index + 1}`}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <CustomTextField
+                              select
+                              size='small'
+                              fullWidth
+                              value={line.unit}
+                              onChange={event => updateLineItem(index, { unit: event.target.value as LineUnit })}
+                              disabled={submitting}
+                              aria-label={`Unidad del ítem ${index + 1}`}
+                            >
+                              {UNIT_OPTIONS.map(option => (
+                                <MenuItem key={option.value} value={option.value}>
+                                  {option.label}
+                                </MenuItem>
+                              ))}
+                            </CustomTextField>
+                          </TableCell>
+                          <TableCell align='right'>
+                            <CustomTextField
+                              size='small'
+                              type='number'
+                              value={line.unitPrice}
+                              onChange={event => {
+                                const raw = event.target.value
+                                const next = raw === '' ? 0 : Number(raw)
+
+                                updateLineItem(index, { unitPrice: Number.isFinite(next) ? next : 0 })
+                              }}
+                              inputProps={{ min: 0, step: 'any' }}
+                              disabled={submitting}
+                              aria-label={`Precio unitario del ítem ${index + 1}`}
+                            />
+                          </TableCell>
+                          <TableCell align='right'>
+                            <Tooltip title='Eliminar ítem'>
+                              <span>
+                                <IconButton
+                                  size='small'
+                                  color='error'
+                                  onClick={() => handleRemoveLine(index)}
+                                  disabled={submitting || lineItems.length === 1}
+                                  aria-label={`Eliminar ítem ${index + 1}`}
+                                >
+                                  <i className='tabler-trash' />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </Box>
+              )}
+            </Box>
+          )}
+
+          {(localError || error) && (
+            <Alert severity='error' role='alert' onClose={() => setLocalError(null)}>
+              {localError ?? error}
+            </Alert>
+          )}
+        </Stack>
+
+        {/* Columna derecha: contexto + addons */}
+        <Box
+          sx={{
+            width: { xs: 0, md: 320 },
+            display: { xs: 'none', md: 'flex' },
+            flexDirection: 'column',
+            borderLeft: theme => `1px solid ${theme.palette.divider}`,
+            overflowY: 'auto',
+            p: 3,
+            gap: 3
+          }}
+        >
+          <QuoteBuilderActions
+            state={builderState}
+            onChange={handleBuilderChange}
+            options={builderOptions}
+            disabled={submitting}
+          />
+          {mode === 'scratch' && canSeeCostStack && (
+            <AddonSuggestionsPanel
+              suggestions={simulation?.addons ?? []}
+              includedSkus={includedAddonSkus}
+              onToggle={handleAddonToggle}
+              outputCurrency={builderState.outputCurrency}
+              loading={simulating}
             />
           )}
+        </Box>
+      </Box>
+
+      {mode === 'scratch' && (
+        <QuoteTotalsFooter
+          output={simulation}
+          outputCurrency={builderState.outputCurrency}
+          loading={simulating}
+          error={simulationError}
         />
-
-        <CustomTextField
-          fullWidth
-          size='small'
-          label='Descripción'
-          required
-          value={description}
-          onChange={event => setDescription(event.target.value)}
-          multiline
-          rows={2}
-          helperText='Resumen del alcance que verá el cliente y el equipo de Finanzas.'
-          disabled={submitting}
-        />
-
-        <CustomTextField
-          select
-          fullWidth
-          size='small'
-          label='Modelo de pricing'
-          value={pricingModel}
-          onChange={event => setPricingModel(event.target.value as PricingModel)}
-          disabled={submitting}
-        >
-          {PRICING_MODEL_OPTIONS.map(option => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </CustomTextField>
-
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-          <CustomTextField
-            select
-            fullWidth
-            size='small'
-            label='Moneda'
-            value={currency}
-            onChange={event => setCurrency(event.target.value as Currency)}
-            disabled={submitting}
-          >
-            {CURRENCY_OPTIONS.map(option => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </CustomTextField>
-          <CustomTextField
-            select
-            fullWidth
-            size='small'
-            label='Frecuencia de facturación'
-            value={billingFrequency}
-            onChange={event => setBillingFrequency(event.target.value as BillingFrequency)}
-            disabled={submitting}
-          >
-            {BILLING_FREQUENCY_OPTIONS.map(option => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </CustomTextField>
-        </Stack>
-
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-          <CustomTextField
-            fullWidth
-            size='small'
-            label='Duración del contrato (meses)'
-            type='number'
-            value={contractDurationMonths}
-            onChange={event => {
-              const raw = event.target.value
-
-              setContractDurationMonths(raw === '' ? '' : Number(raw))
-            }}
-            inputProps={{ min: 0, step: 1 }}
-            helperText='Opcional para proyectos o retainers cortos.'
-            disabled={submitting}
-          />
-          <CustomTextField
-            fullWidth
-            size='small'
-            label='Válida hasta'
-            type='date'
-            value={validUntil}
-            onChange={event => setValidUntil(event.target.value)}
-            InputLabelProps={{ shrink: true }}
-            helperText='Fecha en que expira la oferta comercial.'
-            disabled={submitting}
-          />
-        </Stack>
-
-        {mode === 'scratch' && (
-          <Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-              <Typography variant='subtitle2'>Ítems de la cotización</Typography>
-              <Button
-                size='small'
-                variant='outlined'
-                startIcon={<i className='tabler-plus' />}
-                onClick={handleAddLine}
-                disabled={submitting}
-              >
-                Agregar ítem
-              </Button>
-            </Box>
-            {lineItems.length === 0 ? (
-              <Alert severity='info' role='status'>
-                Agrega al menos un ítem para estimar el precio y la salud de margen.
-              </Alert>
-            ) : (
-              <Box sx={{ overflowX: 'auto' }}>
-                <Table size='small'>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell sx={{ minWidth: 180 }}>Ítem</TableCell>
-                      <TableCell sx={{ minWidth: 80 }} align='right'>Cantidad</TableCell>
-                      <TableCell sx={{ minWidth: 100 }}>Unidad</TableCell>
-                      <TableCell sx={{ minWidth: 120 }} align='right'>Precio unitario</TableCell>
-                      <TableCell sx={{ minWidth: 56 }} />
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {lineItems.map((line, index) => (
-                      <TableRow key={`draft-line-${index}`}>
-                        <TableCell>
-                          <CustomTextField
-                            size='small'
-                            fullWidth
-                            placeholder='Ej. Horas de desarrollo'
-                            value={line.label}
-                            onChange={event => updateLineItem(index, { label: event.target.value })}
-                            disabled={submitting}
-                            aria-label={`Etiqueta del ítem ${index + 1}`}
-                          />
-                        </TableCell>
-                        <TableCell align='right'>
-                          <CustomTextField
-                            size='small'
-                            type='number'
-                            value={line.quantity}
-                            onChange={event => {
-                              const raw = event.target.value
-                              const next = raw === '' ? 0 : Number(raw)
-
-                              updateLineItem(index, { quantity: Number.isFinite(next) ? next : 0 })
-                            }}
-                            inputProps={{ min: 0, step: 'any' }}
-                            disabled={submitting}
-                            aria-label={`Cantidad del ítem ${index + 1}`}
-                          />
-                        </TableCell>
-                        <TableCell>
-                          <CustomTextField
-                            select
-                            size='small'
-                            fullWidth
-                            value={line.unit}
-                            onChange={event => updateLineItem(index, { unit: event.target.value as LineUnit })}
-                            disabled={submitting}
-                            aria-label={`Unidad del ítem ${index + 1}`}
-                          >
-                            {UNIT_OPTIONS.map(option => (
-                              <MenuItem key={option.value} value={option.value}>
-                                {option.label}
-                              </MenuItem>
-                            ))}
-                          </CustomTextField>
-                        </TableCell>
-                        <TableCell align='right'>
-                          <CustomTextField
-                            size='small'
-                            type='number'
-                            value={line.unitPrice}
-                            onChange={event => {
-                              const raw = event.target.value
-                              const next = raw === '' ? 0 : Number(raw)
-
-                              updateLineItem(index, { unitPrice: Number.isFinite(next) ? next : 0 })
-                            }}
-                            inputProps={{ min: 0, step: 'any' }}
-                            disabled={submitting}
-                            aria-label={`Precio unitario del ítem ${index + 1}`}
-                          />
-                        </TableCell>
-                        <TableCell align='right'>
-                          <Tooltip title='Eliminar ítem'>
-                            <span>
-                              <IconButton
-                                size='small'
-                                color='error'
-                                onClick={() => handleRemoveLine(index)}
-                                disabled={submitting || lineItems.length === 1}
-                                aria-label={`Eliminar ítem ${index + 1}`}
-                              >
-                                <i className='tabler-trash' />
-                              </IconButton>
-                            </span>
-                          </Tooltip>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </Box>
-            )}
-          </Box>
-        )}
-
-        {(localError || error) && (
-          <Alert severity='error' role='alert' onClose={() => setLocalError(null)}>
-            {localError ?? error}
-          </Alert>
-        )}
-      </Stack>
+      )}
 
       <Divider />
       <Box sx={{ display: 'flex', gap: 2, p: 4 }}>

--- a/src/views/greenhouse/finance/workspace/QuoteLineCostStack.tsx
+++ b/src/views/greenhouse/finance/workspace/QuoteLineCostStack.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import type { PricingLineOutputV2, PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
+
+import CostStackPanel, {
+  type CostStackLine,
+  type CostStackPanelProps,
+  type CostStackTierFit
+} from '@/components/greenhouse/pricing/CostStackPanel'
+
+export interface QuoteLineCostStackProps {
+
+  /** Output del engine v2 para una línea individual */
+  lineOutput: PricingLineOutputV2
+
+  /** Moneda output del quote */
+  outputCurrency: PricingOutputCurrency
+
+  /** Default expanded del accordion (false por default, quote-builder variant) */
+  defaultExpanded?: boolean
+}
+
+/**
+ * Wrapper adapter que convierte `PricingLineOutputV2` del engine v2 en props
+ * del CostStackPanel primitive. Usa la variant `quote-builder` (accordion).
+ *
+ * Responsabilidad del caller: solo renderizar este componente si
+ * `canViewCostStack(tenant)` es true. El componente primitive asume que el
+ * gating ya fue aplicado por el caller.
+ */
+const QuoteLineCostStack = ({ lineOutput, outputCurrency, defaultExpanded = false }: QuoteLineCostStackProps) => {
+  const lines = useMemo<CostStackLine[]>(() => {
+    const breakdown = lineOutput.costStack.breakdown ?? {}
+    const entries = Object.entries(breakdown)
+
+    if (entries.length === 0) {
+      return [
+        {
+          itemId: 'cost-total',
+          label: 'Costo base',
+          costBase: lineOutput.costStack.totalCostUsd,
+          feeAmount: 0,
+          feeType: 'flat' as const,
+          total: lineOutput.costStack.totalCostUsd
+        }
+      ]
+    }
+
+    return entries.map(([key, value]) => ({
+      itemId: key,
+      label: key,
+      costBase: value,
+      feeAmount: 0,
+      feeType: 'flat' as const,
+      total: value
+    }))
+  }, [lineOutput.costStack])
+
+  const totals = useMemo<CostStackPanelProps['totals']>(() => {
+    const totalCost = lineOutput.costStack.totalCostUsd
+    const priceToClient = lineOutput.suggestedBillRate.totalBillOutputCurrency
+    const grossMargin = priceToClient - totalCost
+
+    return {
+      totalCost,
+      priceToClient,
+      grossMargin,
+      marginPct: lineOutput.effectiveMarginPct
+    }
+  }, [lineOutput])
+
+  const tierFit = useMemo<CostStackTierFit | undefined>(() => {
+    const compliance = lineOutput.tierCompliance
+
+    if (!compliance.tier || compliance.marginMin === null || compliance.marginMin === undefined) return undefined
+    if (compliance.marginOpt === null || compliance.marginOpt === undefined) return undefined
+    if (compliance.marginMax === null || compliance.marginMax === undefined) return undefined
+
+    return {
+      tierCode: compliance.tier,
+      label: compliance.tier,
+      marginMin: compliance.marginMin,
+      marginOpt: compliance.marginOpt,
+      marginMax: compliance.marginMax
+    }
+  }, [lineOutput.tierCompliance])
+
+  return (
+    <CostStackPanel
+      lines={lines}
+      totals={totals}
+      tierFit={tierFit}
+      currency={outputCurrency}
+      variant='quote-builder'
+      defaultExpanded={defaultExpanded}
+    />
+  )
+}
+
+export default QuoteLineCostStack

--- a/src/views/greenhouse/finance/workspace/QuoteLineItemsEditor.tsx
+++ b/src/views/greenhouse/finance/workspace/QuoteLineItemsEditor.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import Autocomplete from '@mui/material/Autocomplete'
 import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -18,12 +17,20 @@ import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
-import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 
 import CustomChip from '@core/components/mui/Chip'
 import CustomTextField from '@core/components/mui/TextField'
+
+import type { PricingLineOutputV2, PricingOutputCurrency, PricingV2LineType } from '@/lib/finance/pricing/contracts'
+
+import SellableItemPickerDrawer, {
+  type SellableItemPickerTab,
+  type SellableSelection
+} from '@/components/greenhouse/pricing/SellableItemPickerDrawer'
+
+import QuoteLineCostStack from './QuoteLineCostStack'
 
 export interface QuoteLineItem {
   lineItemId?: string
@@ -40,15 +47,10 @@ export interface QuoteLineItem {
   memberId?: string | null
   discountType?: 'percentage' | 'fixed_amount' | null
   discountValue?: number | null
-}
-
-export interface QuoteLineItemsEditorProduct {
-  productId: string
-  productName: string
-  productCode: string
-  defaultUnitPrice: number | null
-  defaultUnit: string
-  suggestedRoleCode: string | null
+  metadata?: {
+    pricingV2LineType?: PricingV2LineType
+    sku?: string
+  } | null
 }
 
 export interface QuoteLineItemsEditorProps {
@@ -58,7 +60,17 @@ export interface QuoteLineItemsEditorProps {
   lineItems: QuoteLineItem[]
   onSave: (lines: QuoteLineItem[]) => Promise<void>
   saving: boolean
-  products: QuoteLineItemsEditorProduct[]
+  businessLineCode?: string | null
+
+  /** Gating del cost stack (solo finance/admin). El caller es responsable de
+   * computar este flag con `canViewCostStack(tenant)`. */
+  canViewCostStack?: boolean
+
+  /** Output del engine v2 por línea, indexado por posición. Cuando está disponible
+   * y el viewer tiene permisos, se renderiza el QuoteLineCostStack debajo de cada
+   * línea con tier compliance y breakdown interno. */
+  simulationLines?: PricingLineOutputV2[] | null
+  outputCurrency?: PricingOutputCurrency | null
 }
 
 const LINE_TYPE_OPTIONS: Array<{ value: QuoteLineItem['lineType']; label: string; color: 'primary' | 'info' | 'success' | 'warning' }> = [
@@ -128,10 +140,93 @@ const computeRowSubtotalAfterDiscount = (line: QuoteLineItem): number => {
 
 const cloneLineItems = (items: QuoteLineItem[]): QuoteLineItem[] => items.map(item => ({ ...item }))
 
-const emptyLine = (): QuoteLineItem => ({
+// Mapea una selección del SellableItemPickerDrawer a un QuoteLineItem persistible.
+// engine v2 usa 5 line types; la tabla actual persiste 4 (person/role/deliverable/direct_cost).
+// Para tool y overhead_addon, aplanamos a direct_cost + metadata.pricingV2LineType + metadata.sku
+// (TASK-464e Delta 2026-04-18).
+const mapSelectionToLine = (selection: SellableSelection): QuoteLineItem => {
+  switch (selection.tab) {
+    case 'roles':
+      return {
+        label: selection.label,
+        description: null,
+        lineType: 'role',
+        unit: 'month',
+        quantity: 1,
+        unitPrice: null,
+        subtotalPrice: null,
+        subtotalAfterDiscount: null,
+        roleCode: selection.sku,
+        memberId: null,
+        productId: null,
+        discountType: null,
+        discountValue: null,
+        metadata: { pricingV2LineType: 'role', sku: selection.sku }
+      }
+    case 'tools':
+      return {
+        label: selection.label,
+        description: null,
+        lineType: 'direct_cost',
+        unit: 'unit',
+        quantity: 1,
+        unitPrice: null,
+        subtotalPrice: null,
+        subtotalAfterDiscount: null,
+        roleCode: null,
+        memberId: null,
+        productId: null,
+        discountType: null,
+        discountValue: null,
+        metadata: { pricingV2LineType: 'tool', sku: selection.sku }
+      }
+    case 'overhead':
+      return {
+        label: selection.label,
+        description: null,
+        lineType: 'direct_cost',
+        unit: 'unit',
+        quantity: 1,
+        unitPrice: null,
+        subtotalPrice: null,
+        subtotalAfterDiscount: null,
+        roleCode: null,
+        memberId: null,
+        productId: null,
+        discountType: null,
+        discountValue: null,
+        metadata: { pricingV2LineType: 'overhead_addon', sku: selection.sku }
+      }
+    case 'services':
+    default:
+      return {
+        label: selection.label,
+        description: null,
+        lineType: 'deliverable',
+        unit: 'project',
+        quantity: 1,
+        unitPrice: null,
+        subtotalPrice: null,
+        subtotalAfterDiscount: null,
+        roleCode: null,
+        memberId: null,
+        productId: null,
+        discountType: null,
+        discountValue: null,
+        metadata: { sku: selection.sku }
+      }
+  }
+}
+
+// Persona: el picker tab 'roles' no aplica; usamos lookup type=person.
+// Por simplicidad, reutilizamos el mismo drawer con tab 'roles' y mapeamos
+// al `memberId` cuando el sku viene del endpoint de people. Para MVP Phase 2c,
+// creamos una línea vacía tipo 'person' que el usuario completa manualmente
+// si no hay picker dedicado de people (follow-up).
+const emptyPersonLine = (): QuoteLineItem => ({
   label: '',
   description: null,
-  lineType: 'role',
+  lineType: 'person',
   unit: 'hour',
   quantity: 1,
   unitPrice: null,
@@ -141,7 +236,8 @@ const emptyLine = (): QuoteLineItem => ({
   roleCode: null,
   memberId: null,
   discountType: null,
-  discountValue: null
+  discountValue: null,
+  metadata: { pricingV2LineType: 'person' }
 })
 
 const QuoteLineItemsEditor = ({
@@ -150,24 +246,21 @@ const QuoteLineItemsEditor = ({
   lineItems,
   onSave,
   saving,
-  products
+  businessLineCode = null,
+  canViewCostStack: canViewCostStackProp = false,
+  simulationLines = null,
+  outputCurrency = null
 }: QuoteLineItemsEditorProps) => {
   const [draftLines, setDraftLines] = useState<QuoteLineItem[]>(() => cloneLineItems(lineItems))
   const [dirty, setDirty] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [pickerInitialTab, setPickerInitialTab] = useState<SellableItemPickerTab>('roles')
 
   useEffect(() => {
     if (!dirty) {
       setDraftLines(cloneLineItems(lineItems))
     }
   }, [lineItems, dirty])
-
-  const productById = useMemo(() => {
-    const map = new Map<string, QuoteLineItemsEditorProduct>()
-
-    products.forEach(product => map.set(product.productId, product))
-
-    return map
-  }, [products])
 
   const updateLine = useCallback((index: number, patch: Partial<QuoteLineItem>) => {
     setDraftLines(prev => {
@@ -180,8 +273,20 @@ const QuoteLineItemsEditor = ({
     setDirty(true)
   }, [])
 
-  const handleAddLine = useCallback(() => {
-    setDraftLines(prev => [...prev, emptyLine()])
+  const handleOpenPicker = useCallback((tab: SellableItemPickerTab) => {
+    setPickerInitialTab(tab)
+    setPickerOpen(true)
+  }, [])
+
+  const handlePickerSelect = useCallback((selections: SellableSelection[]) => {
+    if (selections.length === 0) return
+
+    setDraftLines(prev => [...prev, ...selections.map(mapSelectionToLine)])
+    setDirty(true)
+  }, [])
+
+  const handleAddPersonLine = useCallback(() => {
+    setDraftLines(prev => [...prev, emptyPersonLine()])
     setDirty(true)
   }, [])
 
@@ -200,39 +305,12 @@ const QuoteLineItemsEditor = ({
     setDirty(false)
   }, [draftLines, onSave])
 
-  const handleProductSelect = useCallback(
-    (index: number, productId: string | null) => {
-      if (productId === null) {
-        updateLine(index, { productId: null })
-
-        return
-      }
-
-      const product = productById.get(productId)
-
-      if (!product) {
-        updateLine(index, { productId })
-
-        return
-      }
-
-      const currentLine = draftLines[index]
-
-      const nextUnit: QuoteLineItem['unit'] = (['hour', 'month', 'unit', 'project'] as const).includes(
-        product.defaultUnit as QuoteLineItem['unit']
-      )
-        ? (product.defaultUnit as QuoteLineItem['unit'])
-        : currentLine.unit
-
-      updateLine(index, {
-        productId: product.productId,
-        label: currentLine.label.trim() ? currentLine.label : product.productName,
-        unit: nextUnit,
-        unitPrice: currentLine.unitPrice ?? product.defaultUnitPrice,
-        roleCode: product.suggestedRoleCode ?? currentLine.roleCode
-      })
-    },
-    [draftLines, productById, updateLine]
+  const excludedSkus = useMemo(
+    () =>
+      draftLines
+        .map(line => line.metadata?.sku ?? line.roleCode ?? line.productId ?? null)
+        .filter((sku): sku is string => typeof sku === 'string'),
+    [draftLines]
   )
 
   const totalRows = draftLines.length
@@ -324,36 +402,64 @@ const QuoteLineItemsEditor = ({
     <Card elevation={0} sx={{ border: theme => `1px solid ${theme.palette.divider}` }}>
       <CardHeader
         title={`Ítems de la cotización (${totalRows})`}
-        subheader='Edita los ítems y guarda para recalcular precio y margen.'
+        subheader='Agrega ítems vendibles desde el catálogo o crea una línea manual.'
         avatar={
           <Avatar variant='rounded' sx={{ bgcolor: 'primary.lightOpacity' }}>
             <i className='tabler-list-details' style={{ fontSize: 22, color: 'var(--mui-palette-primary-main)' }} />
           </Avatar>
         }
-        action={
+      />
+      <Divider />
+      <Box sx={{ p: 3 }}>
+        <Stack direction='row' spacing={1} flexWrap='wrap' useFlexGap>
           <Button
             variant='outlined'
             size='small'
-            startIcon={<i className='tabler-plus' />}
-            onClick={handleAddLine}
+            startIcon={<i className='tabler-user-star' />}
+            onClick={() => handleOpenPicker('roles')}
             disabled={saving}
           >
-            Agregar ítem
+            + Rol
           </Button>
-        }
-      />
+          <Button
+            variant='outlined'
+            size='small'
+            startIcon={<i className='tabler-user' />}
+            onClick={handleAddPersonLine}
+            disabled={saving}
+          >
+            + Persona
+          </Button>
+          <Button
+            variant='outlined'
+            size='small'
+            startIcon={<i className='tabler-tool' />}
+            onClick={() => handleOpenPicker('tools')}
+            disabled={saving}
+          >
+            + Herramienta
+          </Button>
+          <Button
+            variant='outlined'
+            size='small'
+            startIcon={<i className='tabler-receipt' />}
+            onClick={() => handleOpenPicker('overhead')}
+            disabled={saving}
+          >
+            + Overhead
+          </Button>
+        </Stack>
+      </Box>
       <Divider />
       <Box sx={{ overflowX: 'auto' }}>
         <Table size='small'>
           <TableHead>
             <TableRow>
               <TableCell sx={{ minWidth: 220 }}>Ítem</TableCell>
-              <TableCell sx={{ minWidth: 200 }}>Producto</TableCell>
               <TableCell sx={{ minWidth: 140 }}>Tipo</TableCell>
               <TableCell sx={{ minWidth: 90 }} align='right'>Cantidad</TableCell>
               <TableCell sx={{ minWidth: 110 }}>Unidad</TableCell>
               <TableCell sx={{ minWidth: 130 }} align='right'>Precio unitario</TableCell>
-              <TableCell sx={{ minWidth: 100 }} align='right'>Descuento %</TableCell>
               <TableCell sx={{ minWidth: 110 }} align='right'>Subtotal</TableCell>
               <TableCell sx={{ minWidth: 60 }} />
             </TableRow>
@@ -361,180 +467,120 @@ const QuoteLineItemsEditor = ({
           <TableBody>
             {draftLines.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={9}>
+                <TableCell colSpan={7}>
                   <Box sx={{ textAlign: 'center', py: 4 }} role='status'>
                     <Typography variant='body2' color='text.secondary'>
-                      Aún no agregaste ítems. Usa «Agregar ítem» para comenzar.
+                      Aún no agregaste ítems. Usa los botones de arriba para elegir del catálogo.
                     </Typography>
                   </Box>
                 </TableCell>
               </TableRow>
             ) : (
               draftLines.map((line, index) => {
-                const selectedProduct = line.productId ? productById.get(line.productId) ?? null : null
                 const subtotal = computeRowSubtotalAfterDiscount(line)
-
-                const discountPct =
-                  line.discountType === 'percentage' && line.discountValue !== null && line.discountValue !== undefined
-                    ? line.discountValue
-                    : null
+                const typeMeta = LINE_TYPE_META[line.lineType]
+                const simulationLine = simulationLines?.[index] ?? null
+                const showCostStack = canViewCostStackProp && simulationLine && outputCurrency
 
                 return (
-                  <TableRow key={line.lineItemId ?? `draft-${index}`} hover>
-                    <TableCell>
-                      <Stack spacing={1}>
-                        <CustomTextField
-                          size='small'
-                          fullWidth
-                          placeholder='Ej. Diseño de identidad'
-                          value={line.label}
-                          onChange={event => updateLine(index, { label: event.target.value })}
-                          disabled={saving}
-                          aria-label={`Etiqueta del ítem ${index + 1}`}
-                        />
-                        <CustomTextField
-                          size='small'
-                          fullWidth
-                          placeholder='Descripción (opcional)'
-                          value={line.description ?? ''}
-                          onChange={event =>
-                            updateLine(index, { description: event.target.value.trim() ? event.target.value : null })
-                          }
-                          disabled={saving}
-                          aria-label={`Descripción del ítem ${index + 1}`}
-                        />
-                      </Stack>
-                    </TableCell>
-                    <TableCell>
-                      <Autocomplete
-                        size='small'
-                        options={products}
-                        getOptionLabel={option => `${option.productCode} · ${option.productName}`}
-                        value={selectedProduct}
-                        onChange={(_event, value) => handleProductSelect(index, value ? value.productId : null)}
-                        disabled={saving}
-                        renderInput={params => (
-                          <TextField
-                            {...params}
+                  <>
+                    <TableRow key={line.lineItemId ?? `draft-${index}`} hover>
+                      <TableCell>
+                        <Stack spacing={1}>
+                          <CustomTextField
                             size='small'
-                            placeholder='Producto (opcional)'
-                            aria-label={`Producto del ítem ${index + 1}`}
-                          />
-                        )}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <CustomTextField
-                        select
-                        size='small'
-                        fullWidth
-                        value={line.lineType}
-                        onChange={event => updateLine(index, { lineType: event.target.value as QuoteLineItem['lineType'] })}
-                        disabled={saving}
-                        aria-label={`Tipo del ítem ${index + 1}`}
-                      >
-                        {LINE_TYPE_OPTIONS.map(option => (
-                          <MenuItem key={option.value} value={option.value}>
-                            {option.label}
-                          </MenuItem>
-                        ))}
-                      </CustomTextField>
-                    </TableCell>
-                    <TableCell align='right'>
-                      <CustomTextField
-                        size='small'
-                        type='number'
-                        value={line.quantity}
-                        onChange={event => {
-                          const raw = event.target.value
-                          const next = raw === '' ? 0 : Number(raw)
-
-                          updateLine(index, { quantity: Number.isFinite(next) ? next : 0 })
-                        }}
-                        inputProps={{ min: 0, step: 'any' }}
-                        disabled={saving}
-                        aria-label={`Cantidad del ítem ${index + 1}`}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <CustomTextField
-                        select
-                        size='small'
-                        fullWidth
-                        value={line.unit}
-                        onChange={event => updateLine(index, { unit: event.target.value as QuoteLineItem['unit'] })}
-                        disabled={saving}
-                        aria-label={`Unidad del ítem ${index + 1}`}
-                      >
-                        {UNIT_OPTIONS.map(option => (
-                          <MenuItem key={option.value} value={option.value}>
-                            {option.label}
-                          </MenuItem>
-                        ))}
-                      </CustomTextField>
-                    </TableCell>
-                    <TableCell align='right'>
-                      <CustomTextField
-                        size='small'
-                        type='number'
-                        value={line.unitPrice ?? ''}
-                        onChange={event => {
-                          const raw = event.target.value
-
-                          updateLine(index, { unitPrice: raw === '' ? null : Number(raw) })
-                        }}
-                        inputProps={{ min: 0, step: 'any' }}
-                        disabled={saving}
-                        aria-label={`Precio unitario del ítem ${index + 1}`}
-                      />
-                    </TableCell>
-                    <TableCell align='right'>
-                      <CustomTextField
-                        size='small'
-                        type='number'
-                        value={discountPct ?? ''}
-                        onChange={event => {
-                          const raw = event.target.value
-
-                          if (raw === '') {
-                            updateLine(index, { discountType: null, discountValue: null })
-
-                            return
-                          }
-
-                          const parsed = Number(raw)
-
-                          updateLine(index, {
-                            discountType: 'percentage',
-                            discountValue: Number.isFinite(parsed) ? parsed : null
-                          })
-                        }}
-                        inputProps={{ min: 0, max: 100, step: 'any' }}
-                        disabled={saving}
-                        aria-label={`Descuento del ítem ${index + 1}`}
-                      />
-                    </TableCell>
-                    <TableCell align='right'>
-                      <Typography variant='body2' sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
-                        {formatCurrency(subtotal, currency)}
-                      </Typography>
-                    </TableCell>
-                    <TableCell align='right'>
-                      <Tooltip title='Eliminar ítem'>
-                        <span>
-                          <IconButton
-                            size='small'
-                            color='error'
-                            onClick={() => handleRemoveLine(index)}
+                            fullWidth
+                            placeholder='Ej. Diseño de identidad'
+                            value={line.label}
+                            onChange={event => updateLine(index, { label: event.target.value })}
                             disabled={saving}
-                            aria-label={`Eliminar ítem ${index + 1}`}
-                          >
-                            <i className='tabler-trash' />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </TableCell>
-                  </TableRow>
+                            aria-label={`Etiqueta del ítem ${index + 1}`}
+                          />
+                          {line.metadata?.sku && (
+                            <Typography variant='caption' color='text.secondary'>
+                              SKU {line.metadata.sku}
+                            </Typography>
+                          )}
+                        </Stack>
+                      </TableCell>
+                      <TableCell>
+                        <CustomChip round='true' size='small' variant='tonal' color={typeMeta.color} label={typeMeta.label} />
+                      </TableCell>
+                      <TableCell align='right'>
+                        <CustomTextField
+                          size='small'
+                          type='number'
+                          value={line.quantity}
+                          onChange={event => {
+                            const raw = event.target.value
+                            const next = raw === '' ? 0 : Number(raw)
+
+                            updateLine(index, { quantity: Number.isFinite(next) ? next : 0 })
+                          }}
+                          disabled={saving}
+                          aria-label={`Cantidad del ítem ${index + 1}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <CustomTextField
+                          select
+                          size='small'
+                          fullWidth
+                          value={line.unit}
+                          onChange={event => updateLine(index, { unit: event.target.value as QuoteLineItem['unit'] })}
+                          disabled={saving}
+                          aria-label={`Unidad del ítem ${index + 1}`}
+                        >
+                          {UNIT_OPTIONS.map(option => (
+                            <MenuItem key={option.value} value={option.value}>
+                              {option.label}
+                            </MenuItem>
+                          ))}
+                        </CustomTextField>
+                      </TableCell>
+                      <TableCell align='right'>
+                        <CustomTextField
+                          size='small'
+                          type='number'
+                          value={line.unitPrice ?? ''}
+                          onChange={event => {
+                            const raw = event.target.value
+
+                            updateLine(index, { unitPrice: raw === '' ? null : Number(raw) })
+                          }}
+                          disabled={saving}
+                          aria-label={`Precio unitario del ítem ${index + 1}`}
+                        />
+                      </TableCell>
+                      <TableCell align='right'>
+                        <Typography variant='body2' sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
+                          {formatCurrency(subtotal, currency)}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align='right'>
+                        <Tooltip title='Eliminar ítem'>
+                          <span>
+                            <IconButton
+                              size='small'
+                              color='error'
+                              onClick={() => handleRemoveLine(index)}
+                              disabled={saving}
+                              aria-label={`Eliminar ítem ${index + 1}`}
+                            >
+                              <i className='tabler-trash' />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                    {showCostStack && simulationLine && outputCurrency ? (
+                      <TableRow key={`${line.lineItemId ?? `draft-${index}`}-cost`}>
+                        <TableCell colSpan={7} sx={{ py: 1, bgcolor: 'background.default' }}>
+                          <QuoteLineCostStack lineOutput={simulationLine} outputCurrency={outputCurrency} />
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </>
                 )
               })
             )}
@@ -570,6 +616,15 @@ const QuoteLineItemsEditor = ({
           </Button>
         </Stack>
       </Box>
+
+      <SellableItemPickerDrawer
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={handlePickerSelect}
+        initialTab={pickerInitialTab}
+        businessLineCode={businessLineCode}
+        excludeSkus={excludedSkus}
+      />
     </Card>
   )
 }

--- a/src/views/greenhouse/finance/workspace/QuoteTotalsFooter.tsx
+++ b/src/views/greenhouse/finance/workspace/QuoteTotalsFooter.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress'
+import Skeleton from '@mui/material/Skeleton'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import type { PricingEngineOutputV2, PricingOutputCurrency } from '@/lib/finance/pricing/contracts'
+
+const CURRENCY_LOCALE: Record<PricingOutputCurrency, string> = {
+  CLP: 'es-CL',
+  USD: 'en-US',
+  CLF: 'es-CL',
+  COP: 'es-CO',
+  MXN: 'es-MX',
+  PEN: 'es-PE'
+}
+
+const formatMoney = (amount: number, currency: PricingOutputCurrency): string => {
+  const locale = CURRENCY_LOCALE[currency] ?? 'es-CL'
+
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0
+    }).format(amount)
+  } catch {
+    return `${new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(amount)} ${currency}`
+  }
+}
+
+const formatPct = (value: number): string =>
+  new Intl.NumberFormat('es-CL', { style: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(value)
+
+const classificationMeta: Record<
+  PricingEngineOutputV2['aggregateMargin']['classification'],
+  { label: string; icon: string; color: 'success' | 'warning' | 'error' }
+> = {
+  healthy: { label: 'Saludable', icon: 'tabler-circle-check', color: 'success' },
+  warning: { label: 'Atención', icon: 'tabler-alert-circle', color: 'warning' },
+  critical: { label: 'Crítico', icon: 'tabler-alert-triangle', color: 'error' }
+}
+
+export interface QuoteTotalsFooterProps {
+  output: PricingEngineOutputV2 | null
+  outputCurrency: PricingOutputCurrency
+  loading?: boolean
+  error?: string | null
+}
+
+/**
+ * Footer sticky con totales del engine v2 (subtotal / overhead / total) en USD
+ * y en la moneda output, multipliers aplicados, y chip de salud del margen
+ * agregado (healthy / warning / critical).
+ */
+const QuoteTotalsFooter = ({ output, outputCurrency, loading = false, error = null }: QuoteTotalsFooterProps) => {
+  const theme = useTheme()
+
+  if (error) {
+    return (
+      <Box
+        role='alert'
+        sx={t => ({
+          position: 'sticky',
+          bottom: 0,
+          bgcolor: t.palette.background.paper,
+          borderTop: `1px solid ${t.palette.error.main}`,
+          p: 3
+        })}
+      >
+        <Typography variant='body2' color='error'>
+          {error}
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (!output && !loading) {
+    return (
+      <Box
+        sx={t => ({
+          position: 'sticky',
+          bottom: 0,
+          bgcolor: t.palette.background.paper,
+          borderTop: `1px solid ${t.palette.divider}`,
+          p: 3
+        })}
+      >
+        <Typography variant='body2' color='text.secondary' sx={{ textAlign: 'center' }}>
+          Agrega ítems para calcular el total.
+        </Typography>
+      </Box>
+    )
+  }
+
+  const totals = output?.totals
+  const aggregate = output?.aggregateMargin
+  const meta = aggregate ? classificationMeta[aggregate.classification] : null
+  const palette = meta ? theme.palette[meta.color] : null
+
+  return (
+    <Box
+      component='footer'
+      role='contentinfo'
+      sx={t => ({
+        position: 'sticky',
+        bottom: 0,
+        bgcolor: t.palette.background.paper,
+        borderTop: `1px solid ${t.palette.divider}`,
+        px: 3,
+        py: 2
+      })}
+    >
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        alignItems={{ md: 'center' }}
+        justifyContent='space-between'
+      >
+        <Stack direction='row' spacing={3} flexWrap='wrap'>
+          <TotalsBlock
+            label='Subtotal'
+            primary={loading ? null : formatMoney(totals?.totalOutputCurrency ?? 0, outputCurrency)}
+            secondary={loading ? null : formatMoney(totals?.subtotalUsd ?? 0, 'USD')}
+          />
+          <TotalsBlock
+            label='Overhead'
+            primary={loading ? null : formatMoney(totals?.overheadUsd ?? 0, 'USD')}
+            secondary={
+              totals
+                ? `Mult × ${totals.commercialMultiplierApplied.toFixed(2)} · País × ${totals.countryFactorApplied.toFixed(2)}`
+                : null
+            }
+          />
+          <TotalsBlock
+            label='Total'
+            primary={loading ? null : formatMoney(totals?.totalOutputCurrency ?? 0, outputCurrency)}
+            secondary={loading ? null : formatMoney(totals?.totalUsd ?? 0, 'USD')}
+            emphasized
+          />
+        </Stack>
+
+        {meta && aggregate ? (
+          <Stack direction='row' spacing={2} alignItems='center'>
+            {output?.warnings?.length ? (
+              <Typography
+                variant='caption'
+                color='warning.main'
+                sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+              >
+                <i className='tabler-alert-circle' aria-hidden='true' />
+                {output.warnings.length} {output.warnings.length === 1 ? 'advertencia' : 'advertencias'}
+              </Typography>
+            ) : null}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                px: 1.5,
+                py: 0.75,
+                borderRadius: 1,
+                bgcolor: palette ? alpha(palette.main, 0.12) : undefined,
+                color: palette ? palette.main : undefined,
+                border: palette ? `1px solid ${alpha(palette.main, 0.24)}` : undefined
+              }}
+              aria-label={`Margen ${formatPct(aggregate.marginPct)} — ${meta.label}`}
+            >
+              <i className={meta.icon} aria-hidden='true' style={{ fontSize: 16 }} />
+              <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                {formatPct(aggregate.marginPct)} · {meta.label}
+              </Typography>
+            </Box>
+          </Stack>
+        ) : loading ? (
+          <CircularProgress size={20} aria-label='Calculando precios' />
+        ) : null}
+      </Stack>
+    </Box>
+  )
+}
+
+const TotalsBlock = ({
+  label,
+  primary,
+  secondary,
+  emphasized = false
+}: {
+  label: string
+  primary: string | null
+  secondary: string | null
+  emphasized?: boolean
+}) => (
+  <Box>
+    <Typography variant='caption' color='text.secondary' sx={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+      {label}
+    </Typography>
+    {primary === null ? (
+      <Skeleton variant='text' width={120} height={28} />
+    ) : (
+      <Typography
+        variant={emphasized ? 'h6' : 'body1'}
+        sx={{ fontFamily: 'monospace', fontWeight: emphasized ? 600 : 500, lineHeight: 1.2 }}
+      >
+        {primary}
+      </Typography>
+    )}
+    {secondary ? (
+      <Typography variant='caption' color='text.secondary'>
+        {secondary}
+      </Typography>
+    ) : null}
+  </Box>
+)
+
+export { formatMoney as formatOutputMoney }
+export default QuoteTotalsFooter


### PR DESCRIPTION
## Summary

TASK-464e Phase 1 — infraestructura backend + primitives UI reusables del quote builder pricing. Los refactors grandes (QuoteCreateDrawer + QuoteLineItemsEditor) van en Phase 2 en un PR/commit separado.

## Scope de este PR

### Primitives iniciales (commits 89e332ac + 2bd92704)

- \`MarginIndicatorBadge\` — Chip semáforo margen vs tier (4 estados)
- \`CurrencySwitcher\` — Select 6 monedas \`PricingOutputCurrency\` + disclaimer rate
- \`PricingCatalogNavCard\` — Card nav con CardActionArea + Next Link

### Backend (commit aa697fbf)

- \`canViewCostStack(tenant)\` en \`src/lib/tenant/authorization.ts\` — gate EFEONCE_ADMIN || FINANCE_ADMIN || FINANCE_ANALYST
- \`POST /api/finance/quotes/pricing/simulate\` — engine v2 wrapper, filtra \`costStack\` per-line si el viewer no tiene permiso
- \`GET /api/finance/quotes/pricing/lookup?type=role|tool|addon|person|employment_type\` — autocomplete con cache 5min

### UI primitives (commit aa697fbf)

- \`CostStackPanel.tsx\` — panel breakdown con 2 variants (quote-builder accordion + admin-preview)
- \`SellableItemRow.tsx\` — renderer polimórfico (role/tool/overhead/service)
- \`SellableItemPickerDrawer.tsx\` — drawer 4-tab con lookup + multi-select
- \`usePricingSimulation\` hook — debounce 500ms + AbortController

### Copy extension

- \`GH_PRICING\` extendido con 10+ entradas para drawer (pickerTitle, pickerTabsAriaLabel, etc.)

## Reconciliación vs spec original (delta documentado en TASK-464e.md)

| Aspecto | Spec original | Realidad runtime | Adopción |
|---|---|---|---|
| Pickers | 4 autocompletes separados | TASK-469 canoniza 1 drawer 4-tab | Drawer único, reusable por 465/467 |
| Role gating | \`finance_manager\`, \`finance\` | No existen en ROLE_CODES | FINANCE_ADMIN + FINANCE_ANALYST + EFEONCE_ADMIN |
| Currencies | CLP/USD/EUR/GBP (4) | Engine v2: CLP/USD/CLF/COP/MXN/PEN (6) | 6 monedas LatAm |
| Line types | person/role/deliverable/direct_cost | Engine v2: role/person/tool/overhead_addon/direct_cost | Flattening al persist (phase 2) |
| Entitlements | N/A | finance.cost_stack.view no registrado | Role check directo (MVP); capability follow-up |

## Phase 2 (pendiente, próxima iteración)

- \`QuoteBuilderActions.tsx\` (sidebar con selectores commercial model/country/currency/employment type)
- \`QuoteTotalsFooter.tsx\` (sticky footer totals + margin chip)
- \`AddonSuggestionsPanel.tsx\` (addons auto-resueltos con checkboxes)
- \`QuoteLineCostStack.tsx\` (thin wrapper de CostStackPanel per-line)
- Refactor \`QuoteCreateDrawer.tsx\` (header fields + wiring builder)
- Refactor \`QuoteLineItemsEditor.tsx\` (4 botones picker + live simulate + mapper line types legacy↔v2)

Estos 6 items requieren integrar todo lo anterior en el drawer/editor existente y son más invasivos. Van en PR separado o commit separado continuando este branch.

## Test plan

- [x] \`npx eslint src/app/api/finance/quotes/pricing/ src/components/greenhouse/pricing/ src/hooks/ src/lib/tenant/authorization.ts src/config/greenhouse-nomenclature.ts\` limpio
- [x] \`pnpm vitest run src/components/greenhouse/pricing/ src/lib/payroll/\` → 215/215 passing (194 payroll baseline + 21 pricing primitives)
- [x] Copy 100% desde \`GH_PRICING\`
- [x] 13-row floor cumplido en primitives
- [ ] Integration tests: pendiente Phase 2 cuando el drawer se arma
- [ ] E2E: pendiente Phase 2

## Coexistencia con Codex (Ola 6 en paralelo)

Codex está trabajando TASK-453 en el primary worktree dejando archivos untracked (\`src/lib/commercial/deal-events.ts\`, \`deals-store.ts\`, migrations, cron, vercel.json). NO incluidos en este PR — quedan para que Codex los commitee en su propio branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)