### PR TITLE
fix: harden quote issuance sales context locking

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,27 @@
 # Handoff.md
 
+## Sesion 2026-04-19 — Quote issuance sales-context lock fix (Codex)
+
+- **Owner:** Codex
+- **Estado:** `complete`
+- **Rama:** `fix/codex-quote-issue-for-update`
+- **Worktree:** `/Users/jreye/Documents/greenhouse-eo-fix-quote-issue-for-update`
+- **Problema corregido:**
+  - al emitir una cotización desde el detalle, Postgres devolvía `FOR UPDATE cannot be applied to the nullable side of an outer join`.
+  - el error no estaba en permisos ni en approval logic; ocurría en `captureSalesContextAtSent`, donde el reader de sales context agregaba `FOR UPDATE` al mismo `SELECT` que hace `LEFT JOIN` hacia `clients` y `deals`.
+- **Solución aplicada:**
+  - `src/lib/commercial/sales-context.ts` separa el lock y la lectura:
+    - primero bloquea solo la fila base de `greenhouse_commercial.quotations`
+    - luego carga el snapshot enriquecido sin `FOR UPDATE`
+  - `src/lib/commercial/sales-context.test.ts` agrega regresión explícita para impedir que vuelva a aparecer el patrón `LEFT JOIN + FOR UPDATE`.
+- **Tests / validación:**
+  - `pnpm test -- src/lib/commercial/sales-context.test.ts`
+  - `pnpm lint`
+  - `pnpm build`
+- **Notas de coordinación:**
+  - worktree aislado; no se tocó `data/api_zapsign.txt`.
+  - para validar `build` se reemplazó el symlink de `node_modules` por un árbol hardlinked local, porque Turbopack no acepta symlinks que apunten fuera del root del worktree.
+
 ## Sesion 2026-04-19 — Quote issuance actions + superadmin visibility alignment (Codex)
 
 - **Owner:** Codex

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## 2026-04-19
 
+### 2026-04-19 — Quote issuance sales-context lock stops tripping on LEFT JOINs
+
+- Emitir una cotización desde `/finance/quotes/[id]` ya no falla con `FOR UPDATE cannot be applied to the nullable side of an outer join` cuando el flujo captura `sales_context_at_sent`.
+- El lock transaccional se separa de la lectura enriquecida del snapshot comercial: primero se bloquea solo la fila de `greenhouse_commercial.quotations`, y luego se resuelve el contexto con `LEFT JOIN` sin arrastrar locks inválidos sobre relaciones opcionales.
+- Se agrega una prueba de regresión para asegurar que futuros cambios en el reader de sales context no vuelvan a mezclar `FOR UPDATE` con joins opcionales.
+
 ### 2026-04-19 — Quote issuance actions converge across builder, detail and superadmin access
 
 - El cotizador deja explícitos dos intents distintos: **Guardar borrador** y **Guardar y emitir**. Emitir desde `/finance/quotes/new` o `/finance/quotes/[id]/edit` reutiliza el mismo comando canónico `POST /api/finance/quotes/[id]/issue`, en vez de depender de que el usuario guarde y luego descubra otra pantalla.

--- a/src/lib/commercial/sales-context.test.ts
+++ b/src/lib/commercial/sales-context.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+vi.mock('@/lib/db', () => ({
+  query: vi.fn()
+}))
 
 describe('sales-context', () => {
   it('derives deal, contract and pre-sales categories from local runtime context', async () => {
@@ -58,5 +61,55 @@ describe('sales-context', () => {
       commercialModel: 'project',
       staffingModel: 'outcome_based'
     })
+  })
+
+  it('locks only the quotation row before reading sales context snapshot source', async () => {
+    const { captureSalesContextAtSent } = await import('./sales-context')
+
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ quotation_id: 'qt-1' }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              quotation_id: 'qt-1',
+              organization_id: 'org-1',
+              space_id: 'sp-1',
+              client_id: 'cl-1',
+              hubspot_deal_id: null,
+              sales_context_at_sent: null,
+              pricing_model: 'project',
+              commercial_model: 'project',
+              staffing_model: 'outcome_based',
+              lifecyclestage: 'customer',
+              deal_id: null,
+              dealstage: null
+            }
+          ]
+        })
+        .mockResolvedValueOnce({ rows: [] })
+    }
+
+    const snapshot = await captureSalesContextAtSent({
+      quotationId: 'qt-1',
+      organizationId: 'org-1',
+      spaceId: 'sp-1',
+      client
+    })
+
+    expect(snapshot.categoryAtSent).toBe('contract')
+    expect(client.query).toHaveBeenCalledTimes(3)
+
+    const firstSql = client.query.mock.calls[0]?.[0] as string
+    const secondSql = client.query.mock.calls[1]?.[0] as string
+
+    expect(firstSql).toContain('FROM greenhouse_commercial.quotations AS q')
+    expect(firstSql).toContain('FOR UPDATE')
+    expect(firstSql).not.toContain('LEFT JOIN')
+
+    expect(secondSql).toContain('LEFT JOIN greenhouse_core.clients AS c')
+    expect(secondSql).toContain('LEFT JOIN greenhouse_commercial.deals AS d')
+    expect(secondSql).not.toContain('FOR UPDATE')
   })
 })

--- a/src/lib/commercial/sales-context.ts
+++ b/src/lib/commercial/sales-context.ts
@@ -92,6 +92,10 @@ LEFT JOIN greenhouse_commercial.deals AS d
  )
 WHERE q.quotation_id = $1`
 
+const SALES_CONTEXT_LOCK_SQL = `SELECT q.quotation_id
+FROM greenhouse_commercial.quotations AS q
+WHERE q.quotation_id = $1`
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
@@ -180,8 +184,25 @@ const loadSalesContextSource = async ({
     startIndex: 2
   })
 
-  const sql = `${SALES_CONTEXT_SOURCE_SQL}${scope.sql}${lockForUpdate ? '\nFOR UPDATE' : ''}`
   const params: unknown[] = [quotationId, ...scope.params]
+
+  if (client && lockForUpdate) {
+    const lockSql = `${SALES_CONTEXT_LOCK_SQL}${scope.sql}\nFOR UPDATE`
+    const lockResult = await client.query<{ quotation_id: string }>(lockSql, params)
+
+    if (lockResult.rows.length === 0) {
+      return null
+    }
+
+    const result = await client.query<SalesContextSourceRow>(
+      `${SALES_CONTEXT_SOURCE_SQL}${scope.sql}`,
+      params
+    )
+
+    return result.rows[0] ?? null
+  }
+
+  const sql = `${SALES_CONTEXT_SOURCE_SQL}${scope.sql}`
 
   if (client) {
     const result = await client.query<SalesContextSourceRow>(sql, params)


### PR DESCRIPTION
## Summary
- split quote sales-context locking from the enriched LEFT JOIN reader used during quote issuance
- lock only the quotation row before reading clients/deals context so emit no longer trips Postgres outer-join locking rules
- add a regression test covering the lock/read query separation

## Validation
- pnpm test -- src/lib/commercial/sales-context.test.ts
- pnpm lint
- pnpm build