### PR TITLE
fix: converge quote conversion transaction boundaries

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,30 @@
 # Handoff.md
 
+## Sesion 2026-04-19 — Quote-to-cash conversion transaction convergence (Codex)
+
+- **Owner:** Codex
+- **Estado:** `complete`
+- **Rama:** `fix/codex-quote-conversion-lock`
+- **Worktree:** `/Users/jreye/Documents/greenhouse-eo-fix-quote-conversion-lock`
+- **Problema corregido:**
+  - en la tab `Cadena documental`, el CTA `Convertir a factura` podía quedarse indefinidamente en `Convirtiendo…` aunque la cotización ya estuviera emitida.
+  - el backend no materializaba `income` ni actualizaba `converted_to_income_id`; la cadena seguía sin factura.
+  - la causa estructural era la mezcla de transacciones: `materializeInvoiceFromApprovedQuotation` / `materializeInvoiceFromApprovedHes` abrían una transacción y luego llamaban a `ensureContractForQuotation`, que a su vez abría otra `withTransaction` separada sobre el mismo flujo quote-to-cash.
+- **Solución aplicada:**
+  - `src/lib/commercial/contract-lifecycle.ts` ahora acepta un `client` opcional en `ensureContractForQuotation` y reutiliza el boundary transaccional existente cuando lo recibe.
+  - los materializadores de factura (`simple` y `enterprise`) ahora pasan el mismo `client` activo al lifecycle contractual para evitar transacciones anidadas y esperas por locks/FKs sobre la misma cotización.
+  - se agregan regresiones en:
+    - `src/lib/commercial/contract-lifecycle.test.ts`
+    - `src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.test.ts`
+    - `src/lib/finance/quote-to-cash/materialize-invoice-from-hes.test.ts`
+- **Tests / validación:**
+  - `pnpm test -- src/lib/commercial/contract-lifecycle.test.ts src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.test.ts src/lib/finance/quote-to-cash/materialize-invoice-from-hes.test.ts`
+  - `pnpm lint`
+  - `pnpm build`
+- **Notas de coordinación:**
+  - no se volvió a convertir la cotización del usuario durante el fix; el diagnóstico se hizo leyendo staging y code path.
+  - la cotización inspeccionada (`qt-d5c9a4b5-ba51-4267-a54b-ac721eb46a6c`) seguía `issued` con `convertedToIncomeId = null` mientras se investigaba, así que el bug estaba en conversión, no en emisión.
+
 ## Sesion 2026-04-19 — Quote issuance sales-context lock fix (Codex)
 
 - **Owner:** Codex

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## 2026-04-19
 
+### 2026-04-19 — Quote-to-cash invoice conversion reuses one transaction boundary
+
+- Convertir una cotización emitida a factura ya no mezcla transacciones anidadas entre `materializeInvoiceFromApprovedQuotation` / `materializeInvoiceFromApprovedHes` y `ensureContractForQuotation`.
+- El lifecycle contractual ahora puede reutilizar el `client` transaccional activo cuando la conversión corre dentro de un flujo quote-to-cash, evitando esperas indefinidas por locks/FKs sobre la misma cotización.
+- Se agregan regresiones para ambos caminos de materialización (`simple` y `enterprise`) y para `ensureContractForQuotation`, de modo que futuras refactorizaciones no vuelvan a abrir una segunda transacción dentro del mismo comando.
+
 ### 2026-04-19 — Quote issuance sales-context lock stops tripping on LEFT JOINs
 
 - Emitir una cotización desde `/finance/quotes/[id]` ya no falla con `FOR UPDATE cannot be applied to the nullable side of an outer join` cuando el flujo captura `sales_context_at_sent`.

--- a/src/lib/commercial/contract-lifecycle.test.ts
+++ b/src/lib/commercial/contract-lifecycle.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+  withTransaction: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/contract-events', () => ({
+  publishContractActivated: vi.fn(),
+  publishContractCompleted: vi.fn(),
+  publishContractCreated: vi.fn(),
+  publishContractModified: vi.fn(),
+  publishContractRenewed: vi.fn(),
+  publishContractTerminated: vi.fn()
+}))
+
+import { withTransaction } from '@/lib/db'
+
+const mockedWithTransaction = withTransaction as unknown as ReturnType<typeof vi.fn>
+
+describe('ensureContractForQuotation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reuses the provided client instead of opening a nested transaction', async () => {
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              contract_id: 'ctr-existing-1',
+              contract_number: 'EO-CTR-TEST',
+              status: 'draft',
+              client_id: null,
+              organization_id: 'org-1',
+              space_id: 'space-1',
+              commercial_model: 'project',
+              staffing_model: 'outcome_based',
+              originator_quote_id: 'qt-1'
+            }
+          ]
+        })
+        .mockResolvedValue({ rows: [] })
+    }
+
+    const { ensureContractForQuotation } = await import('./contract-lifecycle')
+
+    const result = await ensureContractForQuotation({
+      quotationId: 'qt-1',
+      actor: { userId: 'user-1', name: 'User Test' },
+      client
+    })
+
+    expect(result).toEqual({
+      contractId: 'ctr-existing-1',
+      contractNumber: 'EO-CTR-TEST',
+      created: false,
+      status: 'draft'
+    })
+
+    expect(mockedWithTransaction).not.toHaveBeenCalled()
+    expect(client.query).toHaveBeenCalled()
+  })
+})

--- a/src/lib/commercial/contract-lifecycle.ts
+++ b/src/lib/commercial/contract-lifecycle.ts
@@ -204,23 +204,25 @@ export const ensureContractForQuotation = async ({
   quotationId,
   actor,
   startDate,
-  endDate
+  endDate,
+  client
 }: {
   quotationId: string
   actor: ContractLifecycleActor
   startDate?: string | null
   endDate?: string | null
+  client?: QueryableClient
 }): Promise<EnsureContractResult> => {
   void actor
 
-  return withTransaction(async client => {
-    const existing = await loadExistingContractForQuote(client, quotationId)
+  const run = async (txClient: QueryableClient) => {
+    const existing = await loadExistingContractForQuote(txClient, quotationId)
 
     if (existing) {
       await syncContractIdOnDocumentChain({
         quotationId,
         contractId: String(existing.contract_id),
-        client
+        client: txClient
       })
 
       return {
@@ -231,7 +233,7 @@ export const ensureContractForQuotation = async ({
       }
     }
 
-    const quote = await loadQuoteForContract(client, quotationId)
+    const quote = await loadQuoteForContract(txClient, quotationId)
 
     if (!quote) {
       throw new Error(`Quotation ${quotationId} not found.`)
@@ -250,7 +252,7 @@ export const ensureContractForQuotation = async ({
       quotationId
     })
 
-    const insert = await client.query(
+    const insert = await txClient.query(
       `INSERT INTO greenhouse_commercial.contracts (
          contract_number,
          client_id,
@@ -306,7 +308,7 @@ export const ensureContractForQuotation = async ({
 
     const contract = insert.rows[0]
 
-    await client.query(
+    await txClient.query(
       `INSERT INTO greenhouse_commercial.contract_quotes (
          contract_id, quotation_id, relationship_type, effective_from
        ) VALUES ($1, $2, 'originator', $3::date)
@@ -317,7 +319,7 @@ export const ensureContractForQuotation = async ({
     await syncContractIdOnDocumentChain({
       quotationId,
       contractId: contract.contract_id,
-      client
+      client: txClient
     })
 
     await publishContractCreated(
@@ -335,7 +337,7 @@ export const ensureContractForQuotation = async ({
         relationshipType: 'originator',
         effectiveAt: new Date().toISOString()
       },
-      client
+      txClient
     )
 
     if (contract.status === 'active') {
@@ -352,7 +354,7 @@ export const ensureContractForQuotation = async ({
           originatorQuoteId: quotationId,
           effectiveAt: new Date().toISOString()
         },
-        client
+        txClient
       )
     }
 
@@ -362,7 +364,13 @@ export const ensureContractForQuotation = async ({
       created: true,
       status: contract.status
     }
-  })
+  }
+
+  if (client) {
+    return run(client)
+  }
+
+  return withTransaction(run)
 }
 
 const attachQuotationToContract = async ({

--- a/src/lib/finance/quote-to-cash/materialize-invoice-from-hes.test.ts
+++ b/src/lib/finance/quote-to-cash/materialize-invoice-from-hes.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/lib/db', () => ({
+  withTransaction: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/governance/audit-log', () => ({
+  recordAudit: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/quotation-events', () => ({
+  publishQuotationInvoiceEmitted: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/contract-lifecycle', () => ({
+  ensureContractForQuotation: vi.fn()
+}))
+
+vi.mock('@/lib/commercial-intelligence/contract-profitability-materializer', () => ({
+  materializeContractProfitabilitySnapshots: vi.fn()
+}))
+
+import { withTransaction } from '@/lib/db'
+import { ensureContractForQuotation } from '@/lib/commercial/contract-lifecycle'
+import { materializeContractProfitabilitySnapshots } from '@/lib/commercial-intelligence/contract-profitability-materializer'
+
+const mockedWithTransaction = withTransaction as unknown as ReturnType<typeof vi.fn>
+const mockedEnsureContractForQuotation = ensureContractForQuotation as unknown as ReturnType<typeof vi.fn>
+
+const mockedMaterializeContractProfitabilitySnapshots = materializeContractProfitabilitySnapshots as unknown as ReturnType<
+  typeof vi.fn
+>
+
+describe('materializeInvoiceFromApprovedHes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes the active transaction client into contract materialization', async () => {
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              hes_id: 'hes-1',
+              hes_number: 'HES-001',
+              purchase_order_id: null,
+              client_id: null,
+              organization_id: 'org-1',
+              space_id: 'space-1',
+              service_description: 'Servicio test',
+              amount: 1000,
+              currency: 'CLP',
+              amount_clp: 1000,
+              amount_authorized_clp: 1000,
+              status: 'approved',
+              income_id: null,
+              quotation_id: 'qt-1'
+            }
+          ]
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              quotation_id: 'qt-1',
+              client_id: null,
+              organization_id: 'org-1',
+              space_id: 'space-1',
+              client_name_cache: 'Cliente Test',
+              status: 'issued',
+              converted_to_income_id: null,
+              current_version: 1
+            }
+          ]
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+    }
+
+    mockedWithTransaction.mockImplementationOnce(async callback => callback(client))
+    mockedEnsureContractForQuotation.mockResolvedValueOnce({
+      contractId: 'ctr-1',
+      contractNumber: 'EO-CTR-TEST',
+      created: true,
+      status: 'draft'
+    })
+    mockedMaterializeContractProfitabilitySnapshots.mockResolvedValueOnce([])
+
+    const { materializeInvoiceFromApprovedHes } = await import('./materialize-invoice-from-hes')
+
+    const result = await materializeInvoiceFromApprovedHes({
+      hesId: 'hes-1',
+      actor: { userId: 'user-1', name: 'User Test' }
+    })
+
+    expect(mockedEnsureContractForQuotation).toHaveBeenCalledWith({
+      quotationId: 'qt-1',
+      actor: { userId: 'user-1', name: 'User Test' },
+      client
+    })
+    expect(mockedMaterializeContractProfitabilitySnapshots).toHaveBeenCalledWith({
+      contractId: 'ctr-1'
+    })
+    expect(result.contractId).toBe('ctr-1')
+  })
+})

--- a/src/lib/finance/quote-to-cash/materialize-invoice-from-hes.ts
+++ b/src/lib/finance/quote-to-cash/materialize-invoice-from-hes.ts
@@ -176,7 +176,8 @@ export const materializeInvoiceFromApprovedHes = async (
 
     const contract = await ensureContractForQuotation({
       quotationId,
-      actor
+      actor,
+      client
     })
 
     await client.query(

--- a/src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.test.ts
+++ b/src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/lib/db', () => ({
+  withTransaction: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/governance/audit-log', () => ({
+  recordAudit: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/quotation-events', () => ({
+  publishQuotationInvoiceEmitted: vi.fn()
+}))
+
+vi.mock('@/lib/commercial/contract-lifecycle', () => ({
+  ensureContractForQuotation: vi.fn()
+}))
+
+vi.mock('@/lib/commercial-intelligence/contract-profitability-materializer', () => ({
+  materializeContractProfitabilitySnapshots: vi.fn()
+}))
+
+import { withTransaction } from '@/lib/db'
+import { ensureContractForQuotation } from '@/lib/commercial/contract-lifecycle'
+import { materializeContractProfitabilitySnapshots } from '@/lib/commercial-intelligence/contract-profitability-materializer'
+
+const mockedWithTransaction = withTransaction as unknown as ReturnType<typeof vi.fn>
+const mockedEnsureContractForQuotation = ensureContractForQuotation as unknown as ReturnType<typeof vi.fn>
+
+const mockedMaterializeContractProfitabilitySnapshots = materializeContractProfitabilitySnapshots as unknown as ReturnType<
+  typeof vi.fn
+>
+
+describe('materializeInvoiceFromApprovedQuotation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes the active transaction client into contract materialization', async () => {
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              quotation_id: 'qt-1',
+              quotation_number: 'EO-QUO-202604-TEST',
+              client_id: null,
+              organization_id: 'org-1',
+              space_id: 'space-1',
+              client_name_cache: 'Cliente Test',
+              status: 'issued',
+              legacy_status: null,
+              converted_to_income_id: null,
+              current_version: 1,
+              total_price: 1000,
+              total_amount: 1000,
+              total_amount_clp: 1000,
+              currency: 'CLP',
+              description: 'Quote test',
+              subtotal: 1000
+            }
+          ]
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: '0' }] })
+        .mockResolvedValueOnce({ rows: [{ cnt: '0' }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+    }
+
+    mockedWithTransaction.mockImplementationOnce(async callback => callback(client))
+    mockedEnsureContractForQuotation.mockResolvedValueOnce({
+      contractId: 'ctr-1',
+      contractNumber: 'EO-CTR-TEST',
+      created: true,
+      status: 'draft'
+    })
+    mockedMaterializeContractProfitabilitySnapshots.mockResolvedValueOnce([])
+
+    const { materializeInvoiceFromApprovedQuotation } = await import('./materialize-invoice-from-quotation')
+
+    const result = await materializeInvoiceFromApprovedQuotation({
+      quotationId: 'qt-1',
+      actor: { userId: 'user-1', name: 'User Test' }
+    })
+
+    expect(mockedEnsureContractForQuotation).toHaveBeenCalledWith({
+      quotationId: 'qt-1',
+      actor: { userId: 'user-1', name: 'User Test' },
+      client
+    })
+    expect(mockedMaterializeContractProfitabilitySnapshots).toHaveBeenCalledWith({
+      contractId: 'ctr-1'
+    })
+    expect(result.contractId).toBe('ctr-1')
+  })
+})

--- a/src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.ts
+++ b/src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.ts
@@ -191,7 +191,8 @@ export const materializeInvoiceFromApprovedQuotation = async (
 
     const contract = await ensureContractForQuotation({
       quotationId,
-      actor
+      actor,
+      client
     })
 
     await client.query(


### PR DESCRIPTION
## Summary
- reuse a single transaction client across quote-to-cash invoice materialization and contract lifecycle creation
- avoid nested  calls when converting quotes/HES into invoices
- add regression coverage for the shared client path in simple and enterprise conversion flows

## Validation
- pnpm test -- src/lib/commercial/contract-lifecycle.test.ts src/lib/finance/quote-to-cash/materialize-invoice-from-quotation.test.ts src/lib/finance/quote-to-cash/materialize-invoice-from-hes.test.ts
- pnpm lint
- pnpm build