### PR TITLE
chore(TASK-574): resolve follow-ups #1-3 (pinned deps, test fixes, Node.js 24 actions)

### DIFF
--- a/.github/workflows/hubspot-greenhouse-integration-deploy.yml
+++ b/.github/workflows/hubspot-greenhouse-integration-deploy.yml
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -110,17 +110,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.DEPLOYER_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 

--- a/services/hubspot_greenhouse_integration/requirements.txt
+++ b/services/hubspot_greenhouse_integration/requirements.txt
@@ -1,3 +1,10 @@
-flask>=2.0
-requests>=2.28
-gunicorn>=22.0
+# Pinned dependencies — TASK-574 follow-up.
+# Floating version ranges (flask>=2.0, etc.) removed post-cutover for
+# reproducible builds. When bumping any pin:
+#   1. Update the version here.
+#   2. Run `python -m pytest services/hubspot_greenhouse_integration/tests/`
+#      locally against the new version.
+#   3. Let CI pytest gate validate before the Cloud Run deploy.
+flask==3.1.3
+requests==2.32.5
+gunicorn==23.0.0

--- a/services/hubspot_greenhouse_integration/tests/test_app.py
+++ b/services/hubspot_greenhouse_integration/tests/test_app.py
@@ -980,14 +980,6 @@ class HubSpotGreenhouseIntegrationAppTests(unittest.TestCase):
             "deals", "hs-deal-existing", "companies", "30825221458"
         )
 
-    @unittest.expectedFailure
-    # Pre-existing sibling test issue inherited by TASK-574 migration.
-    # The app evolved post-this-test-write: when the HubSpotClient mock raises
-    # HubSpotIntegrationError(status_code=429) from find_deal_by_idempotency_key,
-    # the current handler returns 502 (Bad Gateway) instead of propagating 429.
-    # Whether the app behavior or the test expectation is correct is TBD — both
-    # plausible. Tracked as a follow-up to TASK-574 once the service stabilizes
-    # post-cutover.
     def test_deal_create_maps_hubspot_rate_limit_to_retryable_response(self):
         try:
             from services.hubspot_greenhouse_integration.app import create_app
@@ -1004,10 +996,16 @@ class HubSpotGreenhouseIntegrationAppTests(unittest.TestCase):
         )
         client = app.test_client()
 
+        # The real HubSpotClient._classify_error_code() sets error_code
+        # = "HUBSPOT_RATE_LIMIT" on any 429, and the app's
+        # _hubspot_error_response keys on that error_code (not status_code
+        # alone) to map to the 429 response with Retry-After. The fake
+        # exception must mirror that contract.
         fake_hubspot = MagicMock()
         fake_hubspot.find_deal_by_idempotency_key.side_effect = HubSpotIntegrationError(
             "rate limited",
             status_code=429,
+            error_code="HUBSPOT_RATE_LIMIT",
             retry_after="7",
         )
 
@@ -1558,15 +1556,6 @@ class HubSpotGreenhouseIntegrationAppTests(unittest.TestCase):
         self.assertEqual(payload["hubspotProductId"], "hs-42")
         fake_hubspot.archive_product.assert_called_once_with("hs-42")
 
-    @unittest.expectedFailure
-    # Pre-existing sibling test issue inherited by TASK-574 migration.
-    # The `patch("services.hubspot_greenhouse_integration.app.HubSpotClient", return_value=fake_hubspot)`
-    # replaces the HubSpotClient class with a MagicMock, so when app code reads
-    # `HubSpotClient.RECONCILE_PRODUCT_PROPERTIES` it gets an auto-MagicMock
-    # instead of the real class attribute. The assertion then fails because the
-    # recorded call has `properties=<MagicMock>` instead of the expected list.
-    # Proper fix: patch the class attribute separately or use autospec. Tracked
-    # as a follow-up to TASK-574 once the service stabilizes post-cutover.
     def test_product_reconcile_returns_page_and_next_cursor(self):
         try:
             from services.hubspot_greenhouse_integration.app import create_app
@@ -1602,10 +1591,14 @@ class HubSpotGreenhouseIntegrationAppTests(unittest.TestCase):
             "paging": {"next": {"after": "cursor-2"}},
         }
 
+        # Preserve HubSpotClient.RECONCILE_PRODUCT_PROPERTIES on the patched
+        # class: without this, app code reads it as an auto-MagicMock and
+        # the call assertion below fails with properties=<MagicMock>.
         with patch(
             "services.hubspot_greenhouse_integration.app.HubSpotClient",
             return_value=fake_hubspot,
-        ):
+        ) as mock_class:
+            mock_class.RECONCILE_PRODUCT_PROPERTIES = HubSpotClient.RECONCILE_PRODUCT_PROPERTIES
             response = client.get("/products/reconcile?limit=250")
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary

Closes the 3 highest-priority follow-ups left open after the TASK-574 cutover. Bundled into a single PR to minimize deploy runs (one merge = one deploy that validates all three fixes in sequence: pytest → Cloud Build → smoke).

## What ships

### 1. Pinned `requirements.txt`

| Package | Before | After |
|---|---|---|
| flask | `>=2.0` | `==3.1.3` |
| requests | `>=2.28` | `==2.32.5` |
| gunicorn | `>=22.0` | `==23.0.0` |

Removes risk of silent drift when pip resolves floating ranges differently on each Cloud Build.

### 2. Retired the 2 `@unittest.expectedFailure` markers

**`test_deal_create_maps_hubspot_rate_limit_to_retryable_response`** — missing `error_code='HUBSPOT_RATE_LIMIT'` on the fake exception. The app's `_hubspot_error_response` keys on `error_code` (not `status_code` alone), so without it the test hit the default 502 fallback. Fixed by adding the kwarg; test now validates the real contract.

**`test_product_reconcile_returns_page_and_next_cursor`** — patching `HubSpotClient` with plain `MagicMock` replaces the class, so `HubSpotClient.RECONCILE_PRODUCT_PROPERTIES` becomes an auto-MagicMock. Fixed by preserving the real class attribute on the mock after entering the patch context.

Local pytest: **40/40 passing** (was 38 passed + 2 xfailed).

### 3. GitHub Actions → Node.js 24 compatible

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-python | v5 | v6 |
| google-github-actions/auth | v2 | v3 |
| google-github-actions/setup-gcloud | v2 | v3 |

Eliminates the Node.js 20 deprecation warning ahead of the 2026-09-16 EOL.

## Test plan

- [x] pytest local: 40 passed, 0 xfailed, 0 failed
- [ ] pytest en CI: espera 40 passed
- [ ] Cloud Build con requirements pinneadas
- [ ] Smoke `/health=200` + `/contract=200`
- [ ] Sin Node.js 20 deprecation warnings en el workflow

## Risk

Low. Fail-closed en Cloud Run si algo rompe; rollback target `hubspot-greenhouse-integration-00029-ng2` disponible si el deploy regresa algo. Los 3 fixes son independientes — si cualquiera fallara en CI, el merge fixea los otros dos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)