### PR TITLE
TASK-768 followup: sinergia plena con TASK-765 + colaboradores internacionales

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -68,6 +68,7 @@ Documentacion oficial de la plataforma Greenhouse. Cada documento describe como 
 - [Ops Worker — Crons Reactivos en Cloud Run](operations/ops-worker-reactive-crons.md) — servicio Cloud Run que procesa eventos reactivos del outbox, corridas scheduladas, ESM/CJS shim pattern, monitoreo en Ops Health
 - [Commercial Cost Worker](operations/commercial-cost-worker.md) — worker Cloud Run dedicado para la base de costos comercial, su ledger de corridas por periodo/scope y la separacion respecto de `ops-worker`
 - [Postura Cloud GCP](operations/postura-cloud-gcp.md) — estado auditado de Cloud Run, Secret Manager, Cloud SQL, PostgreSQL y BigQuery; qué está sano, qué sigue riesgoso y cómo leer la topología compartida actual
+- [Cloud Cost Intelligence y Copiloto FinOps](operations/cloud-cost-intelligence-finops.md) — lectura funcional del modulo TASK-769: costos GCP, proyeccion, drivers deterministas, alertas tempranas y capa AI para priorizar optimizaciones
 - [Acceso Programatico a Staging](operations/acceso-programatico-staging.md) — como agentes y CI acceden a Staging, bypass de SSO, comando `staging:request`, troubleshooting
 
 ### Delivery

--- a/docs/documentation/operations/cloud-cost-intelligence-finops.md
+++ b/docs/documentation/operations/cloud-cost-intelligence-finops.md
@@ -1,0 +1,151 @@
+# Cloud Cost Intelligence y Copiloto FinOps
+
+> **Tipo de documento:** Documentacion funcional
+> **Version:** 1.0
+> **Creado:** 2026-05-03 por Codex
+> **Modulo:** operaciones / cloud / FinOps
+> **Ruta en portal:** `/admin/integrations`
+> **Arquitectura relacionada:** [GREENHOUSE_BILLING_EXPORT_OBSERVABILITY_V1](../../architecture/GREENHOUSE_BILLING_EXPORT_OBSERVABILITY_V1.md), [GREENHOUSE_RELIABILITY_CONTROL_PLANE_V1](../../architecture/GREENHOUSE_RELIABILITY_CONTROL_PLANE_V1.md)
+> **Task relacionada:** [TASK-769](../../tasks/complete/TASK-769-cloud-cost-intelligence-ai-finops-copilot.md)
+
+## Para que sirve
+
+Cloud Cost Intelligence permite mirar los costos de Google Cloud desde Greenhouse sin depender de entrar a GCP Console para entender lo basico.
+
+La capacidad responde tres preguntas operativas:
+
+- cuanto se esta gastando
+- que servicio, recurso o SKU explica el gasto
+- que conviene revisar primero para evitar que la cuenta siga subiendo
+
+La capa se apoya en `Billing Export` de Google Cloud hacia BigQuery. Greenhouse no reemplaza la factura oficial de GCP ni modifica budgets desde el portal; interpreta datos exportados para hacerlos accionables dentro del flujo operativo.
+
+## Que muestra Greenhouse
+
+En `/admin/integrations`, la tarjeta de costo cloud muestra:
+
+- total del periodo observado
+- moneda reportada por Billing Export
+- ultimo dia de uso disponible
+- forecast mensual explicable
+- top servicios por costo
+- recursos y SKUs que explican el gasto
+- alertas tempranas cuando un driver cruza umbral
+- ultima observacion del Copiloto FinOps AI, si existe
+
+El dato puede tener latencia natural de Billing Export. Por eso Greenhouse muestra el ultimo dia de uso detectado y no asume que el dia actual esta completo.
+
+## Como se calculan los drivers
+
+La severidad no la decide la IA. La decide la capa deterministica.
+
+Greenhouse calcula drivers con reglas auditables:
+
+- `forecast_risk`: la proyeccion mensual cruza umbral de warning o error.
+- `share_of_total`: un servicio concentra una parte excesiva del gasto observado.
+- `service_spike`: un servicio sube contra su baseline reciente.
+- `resource_driver`: un recurso/SKU puntual explica una parte relevante del gasto.
+
+Cada driver trae evidencia concreta: servicio, recurso, SKU, costo, porcentaje del total, fecha de ultimo uso y threshold aplicado.
+
+## Forecast mensual
+
+El forecast es deterministico y esta pensado para ser conservador:
+
+- si ya existen suficientes dias completos del mes, usa promedio del mes actual
+- si el mes recien comenzo, usa una ventana rolling reciente para no subestimar
+- si no hay suficientes datos, baja la confianza y lo declara
+
+Esto puede diferir de la proyeccion que muestra GCP Console, porque Google puede usar reglas propietarias o datos internos no expuestos igual en Billing Export. La lectura de Greenhouse debe tratarse como una explicacion operativa y reproducible, no como reemplazo de la factura.
+
+## Alertas tempranas
+
+Las alertas viven en el `ops-worker`, no en la UI.
+
+El endpoint canonico es:
+
+```text
+POST /cloud-cost-ai-watch
+```
+
+Ese endpoint ejecuta primero la evaluacion deterministica y luego, si esta activada, la capa AI.
+
+El sweep de alertas:
+
+- usa fingerprint para evitar spam
+- respeta cooldown
+- envia Teams como canal primario
+- usa Slack como fallback si Teams no puede despachar
+- soporta `dryRun=true` para smoke checks sin enviar notificaciones ni persistir fingerprints
+
+## Copiloto FinOps AI
+
+El Copiloto FinOps AI interpreta los drivers ya calculados.
+
+Puede producir:
+
+- resumen ejecutivo
+- drivers explicados en lenguaje simple
+- causas probables
+- prioridades de ataque
+- acciones recomendadas
+- telemetria faltante
+- nivel de confianza
+
+La IA no cambia severidad, no dispara alertas por si sola y no inventa metricas. Si falta evidencia, debe declarar incertidumbre.
+
+La activacion es opt-in:
+
+```text
+CLOUD_COST_AI_COPILOT_ENABLED=true
+```
+
+Con el flag apagado, el endpoint retorna `skippedReason` y la experiencia deterministica sigue funcionando.
+
+## Que vive en GCP Console y que vive en Greenhouse
+
+Vive en GCP Console:
+
+- configuracion oficial de Billing Export
+- budgets nativos de GCP
+- factura oficial
+- permisos IAM de billing
+- pricing catalog oficial
+
+Vive en Greenhouse:
+
+- lectura operativa de Billing Export
+- drivers deterministicos
+- forecast explicable
+- proyeccion a Reliability Control Plane
+- alert routing portal-first
+- interpretacion AI grounded
+- documentacion y handoff operativo
+
+## Datos reales verificados al cierre de TASK-769
+
+Al 2026-05-03, Greenhouse verifico:
+
+- dataset `efeonce-group.billing_export`
+- tabla `gcp_billing_export_v1_013340_4C7071_668441`
+- tabla resource-level `gcp_billing_export_resource_v1_013340_4C7071_668441`
+- 30 dias observados: CLP 114.379,91
+- forecast rolling mensual: CLP 121.840,58
+- driver principal: Cloud SQL `greenhouse-pg-dev`
+
+## Limitaciones conocidas
+
+- La lectura depende de que Billing Export siga poblando BigQuery.
+- La latencia natural puede hacer que el dia actual este incompleto.
+- La proyeccion puede diferir de GCP Console.
+- La capa AI requiere Vertex AI/configuracion runtime y esta apagada por defecto.
+- La optimizacion de recursos sigue requiriendo decision humana antes de apagar, reducir o cambiar infraestructura.
+
+## Referencias tecnicas
+
+- Reader: `src/lib/cloud/gcp-billing.ts`
+- Tipos: `src/types/billing-export.ts`
+- UI: `src/components/greenhouse/admin/GcpBillingCard.tsx`
+- Alert sweep: `src/lib/cloud/gcp-billing-alerts.ts`
+- Copiloto AI: `src/lib/cloud/finops-ai/`
+- ops-worker: `services/ops-worker/server.ts`

--- a/docs/manual-de-uso/README.md
+++ b/docs/manual-de-uso/README.md
@@ -29,7 +29,7 @@ _Pendiente._
 
 ### Agencia y Operaciones
 
-_Pendiente._
+- [Monitorear Costos Cloud con FinOps](operations/monitorear-costos-cloud-finops.md) — como revisar gasto GCP, interpretar proyecciones y drivers, usar alertas tempranas y ejecutar diagnosticos seguros sin depender solo de la consola de Google Cloud.
 
 ### Plataforma
 

--- a/docs/manual-de-uso/operations/monitorear-costos-cloud-finops.md
+++ b/docs/manual-de-uso/operations/monitorear-costos-cloud-finops.md
@@ -1,0 +1,243 @@
+# Monitorear Costos Cloud con FinOps
+
+> **Tipo de documento:** Manual de uso
+> **Version:** 1.0
+> **Creado:** 2026-05-03 por Codex
+> **Modulo:** operaciones / cloud / FinOps
+> **Ruta en portal:** `/admin/integrations`
+> **Documentacion relacionada:** [Cloud Cost Intelligence y Copiloto FinOps](../../documentation/operations/cloud-cost-intelligence-finops.md)
+
+## Para que sirve
+
+Este manual explica como usar Greenhouse para revisar costos de Google Cloud, detectar que se disparo y decidir donde atacar primero.
+
+Usalo cuando:
+
+- la factura subio inesperadamente
+- GCP proyecta un pago mayor al esperado
+- quieres saber si Cloud SQL, Cloud Run, Vertex AI, BigQuery u otro servicio esta empujando el gasto
+- necesitas validar si una alerta temprana tiene evidencia suficiente
+
+## Antes de empezar
+
+Necesitas acceso admin al portal Greenhouse.
+
+Tambien debes tener presente:
+
+- Billing Export puede tener latencia natural de hasta 24h.
+- Greenhouse no reemplaza la factura oficial de GCP.
+- No apagues ni reduzcas recursos productivos solo por una recomendacion AI.
+- Las alertas deterministicas son la fuente de severidad; la IA solo explica y prioriza.
+
+## Paso a paso
+
+1. Entra a Greenhouse.
+2. Abre `/admin/integrations`.
+3. Busca la tarjeta **Costo cloud (Billing Export)**.
+4. Revisa el chip de estado:
+   - `Activo`: hay datos disponibles.
+   - `Esperando datos`: Billing Export existe, pero aun no hay filas utiles.
+   - `Sin configurar`: falta project/dataset/configuracion.
+   - `Error`: el reader no pudo consultar BigQuery.
+5. Revisa el total del periodo y el ultimo dia disponible.
+6. Mira la **Proyeccion mensual**.
+7. Revisa **Alertas tempranas**.
+8. Baja a **Top servicios** para ver que servicio concentra gasto.
+9. Revisa **Recursos que explican el gasto** para identificar instancia, recurso o SKU.
+10. Si existe bloque **Copiloto FinOps AI**, leelo como interpretacion, no como fuente de verdad.
+
+## Como leer el forecast
+
+El forecast muestra una proyeccion de cierre mensual.
+
+Interpreta la confianza asi:
+
+- `high`: hay suficientes dias completos para una lectura estable.
+- `medium`: hay datos, pero conviene revisar de nuevo mas adelante.
+- `low`: el periodo observado es muy corto o incompleto.
+
+Si GCP Console muestra otra proyeccion, compara ambas:
+
+- Greenhouse explica su metodo con Billing Export.
+- GCP Console puede usar un metodo propietario.
+- Si ambas apuntan a crecimiento, trata el costo como riesgo real.
+
+## Como interpretar alertas tempranas
+
+Cada alerta incluye resumen y evidencia.
+
+Prioriza en este orden:
+
+1. Drivers `error`.
+2. Recursos/SKUs con alto porcentaje del total.
+3. Servicios que concentran mas de la mitad del gasto.
+4. Forecast que cruza umbral mensual.
+5. Spikes de servicios con aumento contra baseline.
+
+Ejemplo:
+
+```text
+greenhouse-pg-dev concentra 25.2% del costo observado en Cloud SQL.
+```
+
+Esto significa que el primer lugar para investigar es esa instancia o SKU, no "todo GCP".
+
+## Que revisar segun servicio
+
+### Cloud SQL
+
+Revisa:
+
+- instancia exacta
+- vCPU y RAM
+- si es dev/staging/prod
+- tamaño de maquina
+- backups, HA, storage y replicas
+- si existen instancias antiguas o duplicadas
+
+No hacer:
+
+- apagar una instancia sin confirmar ambiente y dependencias
+- bajar recursos sin ventana de cambio
+- tocar produccion sin rollback
+
+### Cloud Run
+
+Revisa:
+
+- min instances
+- memoria y CPU asignada
+- concurrencia
+- servicios legacy publicos
+- jobs que quedaron corriendo mas de lo esperado
+
+No hacer:
+
+- poner `minScale=0` en servicios que necesitan warm start sin validar impacto
+- cambiar identidad o permisos junto con optimizacion de costo en el mismo paso si no esta planeado
+
+### Vertex AI / Gemini
+
+Revisa:
+
+- jobs o runners AI activos
+- frecuencia de scheduler
+- dedupe por fingerprint
+- prompts que puedan estar ejecutandose demasiado
+- kill-switches
+
+No hacer:
+
+- dejar un watcher AI activo sin umbral, dedupe o schedule conservador
+
+### BigQuery
+
+Revisa:
+
+- queries sin particion
+- caps de `maximumBytesBilled`
+- tablas grandes consultadas por crons
+- scheduled queries o materializaciones
+
+No hacer:
+
+- abrir queries exploratorias sin limite o filtro temporal
+
+## Como probar alertas sin enviar mensajes
+
+El endpoint operativo soporta dry-run:
+
+```text
+POST /cloud-cost-ai-watch
+Body: { "triggeredBy": "manual", "dryRun": true }
+```
+
+Un dry-run:
+
+- evalua drivers
+- no manda Teams
+- no manda Slack
+- no persiste fingerprint
+- devuelve counts y `skippedReason`
+
+Usalo para validar que el sistema detecta riesgos antes de activar despachos reales.
+
+## Activar o desactivar el Copiloto AI
+
+La capa AI esta apagada por defecto.
+
+Para activarla en el runtime del ops-worker:
+
+```text
+CLOUD_COST_AI_COPILOT_ENABLED=true
+```
+
+Para apagarla:
+
+```text
+CLOUD_COST_AI_COPILOT_ENABLED=false
+```
+
+Con la IA apagada:
+
+- las alertas deterministicas siguen funcionando
+- la UI sigue mostrando costos, forecast y drivers
+- el endpoint devuelve `skippedReason`
+- no se consumen tokens por interpretacion AI
+
+## Que no hacer
+
+- No tomar decisiones destructivas solo por el resumen AI.
+- No asumir que el dia actual esta completo.
+- No comparar forecast de Greenhouse y GCP Console como si usaran el mismo metodo.
+- No arreglar costos tocando seguridad, IAM o networking en el mismo cambio sin plan.
+- No enviar alertas desde la UI ni desde un GET; el envio vive en el sweep del ops-worker.
+
+## Problemas comunes
+
+### La tarjeta dice "Esperando datos"
+
+Puede significar que Billing Export esta configurado pero BigQuery aun no materializa filas para el periodo observado.
+
+Accion:
+
+- esperar la ventana natural de Billing Export
+- confirmar dataset y tablas en BigQuery
+- revisar arquitectura de Billing Export si persiste
+
+### No aparece el Copiloto AI
+
+Puede estar apagado o no haber observaciones persistidas.
+
+Accion:
+
+- confirmar `CLOUD_COST_AI_COPILOT_ENABLED`
+- revisar que el scheduler haya corrido
+- revisar respuesta de `/cloud-cost-ai-watch`
+
+### Hay alerta pero no llego a Teams
+
+Puede faltar canal Teams o estar deshabilitado.
+
+Accion:
+
+- revisar `CLOUD_COST_ALERT_TEAMS_CHANNEL_CODE`
+- revisar fallback Slack
+- revisar tabla `greenhouse_ai.cloud_cost_alert_dispatches`
+
+### El forecast de Greenhouse no coincide con GCP Console
+
+Es esperado si el metodo de GCP usa datos o supuestos distintos.
+
+Accion:
+
+- usar Greenhouse para entender drivers y evidencia
+- usar GCP Console para factura/proyeccion oficial
+- si ambas muestran tendencia al alza, investigar los drivers principales
+
+## Referencias tecnicas
+
+- Documentacion funcional: `docs/documentation/operations/cloud-cost-intelligence-finops.md`
+- Arquitectura Billing Export: `docs/architecture/GREENHOUSE_BILLING_EXPORT_OBSERVABILITY_V1.md`
+- Arquitectura Reliability: `docs/architecture/GREENHOUSE_RELIABILITY_CONTROL_PLANE_V1.md`
+- Task: `docs/tasks/complete/TASK-769-cloud-cost-intelligence-ai-finops-copilot.md`

--- a/migrations/20260503131202973_task-768-followup-international-collaborators-clear-for-resolver.sql
+++ b/migrations/20260503131202973_task-768-followup-international-collaborators-clear-for-resolver.sql
@@ -1,0 +1,84 @@
+-- Up Migration
+
+-- TASK-768 followup — Limpiar economic_category de pagos a colaboradores
+-- internacionales SIN RUT chileno (Daniela España, Andrés Colombia) y sus
+-- FX fees asociados, para que el resolver actualizado los re-clasifique
+-- correctamente como labor_cost_external.
+--
+-- Causa: el resolver V1 NO capturaba colaboradores sin RUT chileno y sin
+-- registro en `members`. Esos pagos cayeron a ACCOUNTING_TYPE_AMBIGUOUS_FALLBACK
+-- → vendor_cost_saas. El resolver V1.1 (mismo commit) introduce las rules
+-- DIRECT_MEMBER_COST_CATEGORY y FX_FEE_COST_OF_PAYROLL que cubren este caso
+-- usando `cost_category='direct_member'` como signal canónica + heurística
+-- de "nombre humano".
+--
+-- Esta migration:
+--   1. Identifica filas que cumplen el criterio del re-resolve (cost_category
+--      = direct_member + economic_category mal-asignado).
+--   2. Inserta audit log row con previous_category (append-only).
+--   3. NULL-ea economic_category de esas filas.
+--   4. Marca las filas en manual queue como archived (perdieron la
+--      candidate_category sesgada; el operador/backfill las re-resolverá).
+--
+-- Cero impacto en saldos / totales — solo cambia clasificación analítica.
+-- Re-run del backfill (`pnpm tsx scripts/finance/backfill-economic-category.ts`)
+-- aplica el resolver V1.1 a estas filas.
+--
+-- Idempotente: solo afecta filas que cumplen el criterio. Re-run no impacta.
+
+BEGIN;
+
+-- 1. Audit log de la limpieza (append-only).
+INSERT INTO greenhouse_finance.economic_category_resolution_log
+  (log_id, target_kind, target_id, resolved_category, matched_rule,
+   confidence, evidence_json, resolved_by, batch_id)
+SELECT
+  'ecr-intl-clear-' || gen_random_uuid()::text,
+  'expense',
+  e.expense_id,
+  COALESCE(e.economic_category, 'NULL_PRE_RESOLVE'),  -- log el valor que estamos limpiando
+  'INTERNATIONAL_COLLABORATOR_CLEAR_FOR_RERESOLVE',
+  'high',
+  jsonb_build_object(
+    'previous_category', e.economic_category,
+    'reason', 'cost_category=direct_member + colaborador internacional sin RUT chileno mal-clasificado por resolver V1. Limpieza para re-resolve via DIRECT_MEMBER_COST_CATEGORY_HUMAN_NAME / FX_FEE_COST_OF_PAYROLL rules en resolver V1.1.',
+    'expense_type', e.expense_type,
+    'cost_category', e.cost_category,
+    'supplier_name', e.supplier_name,
+    'description_snippet', LEFT(e.description, 100)
+  ),
+  'migration-task-768-international-followup',
+  'migration-20260503131202973'
+FROM greenhouse_finance.expenses e
+WHERE e.cost_category = 'direct_member'
+  AND e.economic_category IS NOT NULL
+  AND e.economic_category NOT IN ('labor_cost_internal', 'labor_cost_external');
+
+-- 2. NULL economic_category de las filas afectadas.
+UPDATE greenhouse_finance.expenses
+   SET economic_category = NULL
+ WHERE cost_category = 'direct_member'
+   AND economic_category IS NOT NULL
+   AND economic_category NOT IN ('labor_cost_internal', 'labor_cost_external');
+
+-- 3. Archivar manual queue rows obsoletos (candidate_category quedó sesgado).
+UPDATE greenhouse_finance.economic_category_manual_queue
+   SET status = 'archived',
+       resolved_by = 'migration-task-768-international-followup',
+       resolved_at = NOW(),
+       resolution_note = 'Archivado: resolver V1.1 lo re-clasificará via DIRECT_MEMBER_COST_CATEGORY rules.'
+ WHERE target_kind = 'expense'
+   AND status = 'pending'
+   AND target_id IN (
+     SELECT expense_id FROM greenhouse_finance.expenses
+     WHERE cost_category = 'direct_member'
+       AND economic_category IS NULL
+   );
+
+COMMIT;
+
+-- Down Migration
+
+-- Reverso intencionalmente NO destructivo — el re-resolve es idempotente
+-- vía backfill. Si emerge necesidad de revertir manualmente, las filas en
+-- audit log preservan la previous_category para reconstrucción.

--- a/src/lib/finance/__tests__/postgres-store-slice2.test.ts
+++ b/src/lib/finance/__tests__/postgres-store-slice2.test.ts
@@ -431,11 +431,17 @@ describe('createFinanceIncomeInPostgres', () => {
     expect(result.incomeId).toBe('INC-202603-001')
     expect(result.clientName).toBe('Acme Corp')
 
-    // client.query called twice: INSERT income + INSERT outbox event
-    expect(mockClientQuery).toHaveBeenCalledTimes(2)
-    const firstCall = mockClientQuery.mock.calls[0]?.[0] as string
+    // TASK-768: client.query called 3 times:
+    //   1. INSERT economic_category_resolution_log (resolver write-time)
+    //   2. INSERT income
+    //   3. INSERT outbox event
+    expect(mockClientQuery).toHaveBeenCalledTimes(3)
 
-    expect(firstCall).toContain('INSERT INTO greenhouse_finance.income')
+    // Verify INSERT income is among the calls (no longer first due to resolver)
+    const calls = mockClientQuery.mock.calls.map(c => c[0] as string)
+
+    expect(calls.some(s => s.includes('INSERT INTO greenhouse_finance.income (\n'))).toBe(true)
+    expect(calls.some(s => s.includes('economic_category_resolution_log'))).toBe(true)
   })
 })
 
@@ -487,9 +493,14 @@ describe('createFinanceExpenseInPostgres', () => {
 
     expect(mockWithGreenhousePostgresTransaction).toHaveBeenCalledTimes(1)
     expect(result.expenseId).toBe('EXP-202603-001')
-    const insertQuery = mockClientQuery.mock.calls[0]?.[0] as string
 
-    expect(insertQuery).toContain('INSERT INTO greenhouse_finance.expenses')
+    // TASK-768: resolver canónico ejecuta antes del INSERT principal.
+    // El INSERT a expenses ya no es el primer query. Verificamos que está
+    // en la lista de queries ejecutadas.
+    const queries = mockClientQuery.mock.calls.map(c => c[0] as string)
+
+    expect(queries.some(s => /INSERT INTO greenhouse_finance\.expenses/.test(s))).toBe(true)
+    expect(queries.some(s => s.includes('economic_category_resolution_log'))).toBe(true)
   })
 
   it('uses provided external client directly without calling withGreenhousePostgresTransaction', async () => {

--- a/src/lib/finance/economic-category/__tests__/resolver.test.ts
+++ b/src/lib/finance/economic-category/__tests__/resolver.test.ts
@@ -227,6 +227,83 @@ describe('TASK-768 resolveExpenseEconomicCategory', () => {
     expect(result.matchedRule).toBe('KNOWN_REGULATOR_REGEX')
   })
 
+  it('Rule 3.5: DIRECT_MEMBER + human name without member match (Daniela España caso real)', async () => {
+    // Colaboradora sin RUT chileno, sin email, sin registro en members.
+    // El cost_category='direct_member' + beneficiary humano es signal canónica.
+    lookupMemberByDisplayNameMock.mockResolvedValueOnce(null)
+
+    const result = await resolveExpenseEconomicCategory({
+      beneficiaryName: 'Daniela Alejandra Ferreira Toro',
+      costCategory: 'direct_member',
+      rawDescription: 'Envío a Daniela Alejandra Ferreira Toro (España) — Nómina Marzo'
+    })
+
+    expect(result.category).toBe('labor_cost_external')
+    expect(result.confidence).toBe('medium')
+    expect(result.matchedRule).toBe('DIRECT_MEMBER_COST_CATEGORY_HUMAN_NAME')
+  })
+
+  it('Rule 3.5: DIRECT_MEMBER + human name CON member match (Andrés Colombia si registrado)', async () => {
+    lookupMemberByDisplayNameMock.mockResolvedValueOnce({
+      memberId: 'member-andres',
+      identityProfileId: 'profile-andres',
+      displayName: 'Andrés Carlosama Termal',
+      employmentType: 'international',
+      primaryEmail: 'andres@efeonce.org',
+      active: true,
+      payrollVia: 'global66',
+      deelContractId: null
+    })
+
+    const result = await resolveExpenseEconomicCategory({
+      beneficiaryName: 'Andrés Carlosama Termal',
+      costCategory: 'direct_member',
+      rawDescription: 'Envío a Andrés (Colombia) — Pago Nómina Marzo'
+    })
+
+    expect(result.category).toBe('labor_cost_external')
+    expect(result.confidence).toBe('high')
+    expect(result.matchedRule).toBe('DIRECT_MEMBER_COST_CATEGORY_WITH_MEMBER_MATCH')
+  })
+
+  it('Rule 3.5: DIRECT_MEMBER NO matchea con corporate beneficiary (Adobe, etc.)', async () => {
+    // Beneficiary es brand corporativa → NO matchea looksLikeHumanName → cae a regla siguiente
+    const result = await resolveExpenseEconomicCategory({
+      beneficiaryName: 'Adobe',
+      costCategory: 'direct_member',
+      accountingType: 'supplier'
+    })
+
+    // Debe caer a ACCOUNTING_TYPE_AMBIGUOUS_FALLBACK, NO a DIRECT_MEMBER
+    expect(result.matchedRule).not.toBe('DIRECT_MEMBER_COST_CATEGORY_HUMAN_NAME')
+    expect(result.matchedRule).toBe('ACCOUNTING_TYPE_AMBIGUOUS_FALLBACK')
+  })
+
+  it('Rule 3.6: FX fee con cost_category=direct_member + description menciona nómina', async () => {
+    const result = await resolveExpenseEconomicCategory({
+      beneficiaryName: null,
+      costCategory: 'direct_member',
+      rawDescription: 'Costo tipo de cambio (Andrés Colombia nómina marzo)'
+    })
+
+    expect(result.category).toBe('labor_cost_external')
+    expect(result.confidence).toBe('medium')
+    expect(result.matchedRule).toBe('FX_FEE_COST_OF_PAYROLL')
+  })
+
+  it('Rule 3.6: bank_fee NO de payroll (mantención cuenta) → NO matchea FX fee rule', async () => {
+    const result = await resolveExpenseEconomicCategory({
+      beneficiaryName: null,
+      costCategory: 'overhead',
+      rawDescription: 'COM.MANTENCION PLAN',
+      accountingType: 'bank_fee'
+    })
+
+    // Cae a ACCOUNTING_TYPE_AMBIGUOUS_FALLBACK con bank_fee_real
+    expect(result.matchedRule).not.toBe('FX_FEE_COST_OF_PAYROLL')
+    expect(result.category).toBe('bank_fee_real')
+  })
+
   it('Rule 4: name fuzzy match (single result)', async () => {
     lookupMemberByDisplayNameMock.mockResolvedValueOnce(internalMember)
 

--- a/src/lib/finance/economic-category/resolver.ts
+++ b/src/lib/finance/economic-category/resolver.ts
@@ -71,6 +71,61 @@ export interface ResolveIncomeResult {
 }
 
 /**
+ * Patrones de "naturaleza corporativa" en el beneficiary_name.
+ * Si matchea alguno de estos sufijos/keywords → es entidad corporativa, NO persona natural.
+ *
+ * Cobertura intencional:
+ *   - Sufijos legales chilenos: SpA, Ltda, S.A., S. de R.L., E.I.R.L.
+ *   - Sufijos legales internacionales: Inc., Corp., LLC, Ltd, GmbH, BV, AG, AB, Pty
+ *   - Vendors corporativos populares (Adobe, Vercel, Notion, Anthropic, etc. — vienen como
+ *     `supplier_name` sin sufijo legal)
+ *   - Strings genéricos de transferencia/costo/comisión que indican que el beneficiary
+ *     no es una persona específica
+ */
+const CORPORATE_BENEFICIARY_REGEX =
+  /\b(SpA|Ltda\.?|S\.A\.?|S\.\s*de\s*R\.L\.?|E\.I\.R\.L\.?|Inc\.?|Corp\.?|LLC|Ltd\.?|GmbH|B\.?V\.?|AG|AB|Pty|Company|Co\.?|Group|Holdings?|Subscriptions?|Hosting|Cloud|API|Plan|Suite|Workspace|Pago\s+(Cuota|Crédito)|Comisión|FX\s+fee|Costo\s+tipo\s+de\s+cambio)\b/i
+
+const KNOWN_CORPORATE_BRANDS_REGEX =
+  /\b(Adobe|Vercel|Notion|Anthropic|OpenAI|GitHub|Google|Microsoft|Amazon|AWS|Stripe|Twilio|Slack|Zoom|HubSpot|Shopify|Linear|Figma|Atlassian|Datadog|Sentry|Cloudflare|Mastercard|Visa|MercadoPago|PayPal|Wise|Beeconta|Nubox|Toku|Metricool|ElevenLabs|Claude\.ai|Envato|Spotify|Netflix|Dropbox|Apple)\b/i
+
+/**
+ * Detecta si un beneficiary_name corresponde a una persona natural (no entidad corporativa).
+ *
+ * Heurística:
+ *   - Tiene 2+ palabras (firstName lastName mínimo)
+ *   - NO matchea sufijos corporativos
+ *   - NO matchea brands corporativas conocidas
+ *   - NO contiene solo dígitos / símbolos (descarta refs de transacción)
+ *
+ * Ejemplos:
+ *   "Daniela Alejandra Ferreira Toro"        → true (persona natural)
+ *   "Andrés Carlosama Termal"                → true
+ *   "Adobe"                                  → false (corporate brand)
+ *   "Beeconta SpA"                           → false (sufijo legal)
+ *   "Deel Inc."                              → false (sufijo legal)
+ *   "Costo tipo de cambio (Andrés Colombia)" → false (descripción genérica de FX fee)
+ */
+export const looksLikeHumanName = (name: string | null | undefined): boolean => {
+  if (!name) return false
+
+  const trimmed = name.trim()
+
+  if (trimmed.length < 5) return false
+
+  // Descarta strings que son claramente descripciones genéricas
+  if (CORPORATE_BENEFICIARY_REGEX.test(trimmed)) return false
+  if (KNOWN_CORPORATE_BRANDS_REGEX.test(trimmed)) return false
+
+  // Debe tener 2+ palabras (firstName lastName mínimo)
+  const wordCount = trimmed
+    .split(/\s+/)
+    .filter(w => /^[\p{L}'-]{2,}$/u.test(w))
+    .length
+
+  return wordCount >= 2
+}
+
+/**
  * Mapping employment_type → economic_category cuando hay member match.
  */
 const memberToExpenseCategory = (
@@ -202,6 +257,82 @@ export const resolveExpenseEconomicCategory = async (
         confidence: 'high',
         matchedRule: 'IDENTITY_MATCH_BY_EMAIL',
         evidence: { ...evidence, reason, member_id: member.memberId, email: emailFromName }
+      }
+    }
+  }
+
+  // Rule 3.5 — DIRECT_MEMBER_COST_CATEGORY (TASK-768 followup)
+  //
+  // Cubre el caso de colaboradores internacionales SIN RUT chileno (Daniela
+  // España, Andrés Colombia) cuyos pagos vienen via Global66/transferencia
+  // directa con `cost_category='direct_member'`. Esa columna es signal
+  // canónica que identifica que el costo es atribuible a una persona; cuando
+  // el beneficiary tiene patrón de nombre humano + cost_category='direct_member',
+  // es seguro decir labor_cost_external (no son colaboradores Chile internos
+  // porque ya hubieran matched Rule 2 RUT).
+  //
+  // FX fees con cost_category='direct_member' (tipo cambio asociado a una
+  // remesa internacional de nómina) también se capturan como labor_cost_external
+  // — son cost-of-payroll, no overhead bancario genérico.
+  if (
+    input.costCategory === 'direct_member' &&
+    looksLikeHumanName(beneficiaryName)
+  ) {
+    // Intentar elevar confidence buscando member match por nombre fuzzy
+    const member = await lookupMemberByDisplayName(beneficiaryName)
+
+    if (member) {
+      const { category, reason } = memberToExpenseCategory(member)
+
+      return {
+        category,
+        confidence: 'high',
+        matchedRule: 'DIRECT_MEMBER_COST_CATEGORY_WITH_MEMBER_MATCH',
+        evidence: {
+          ...evidence,
+          reason,
+          member_id: member.memberId,
+          matched_name: member.displayName,
+          cost_category_hint: 'direct_member'
+        }
+      }
+    }
+
+    // No matchea members, pero cost_category='direct_member' + nombre humano
+    // es signal suficiente para clasificar como labor externo (no Chile interno).
+    return {
+      category: 'labor_cost_external',
+      confidence: 'medium',
+      matchedRule: 'DIRECT_MEMBER_COST_CATEGORY_HUMAN_NAME',
+      evidence: {
+        ...evidence,
+        beneficiary_name: beneficiaryName,
+        cost_category_hint: 'direct_member',
+        reason: 'cost_category=direct_member + human-name pattern → labor_cost_external (collaborator without member registration)'
+      }
+    }
+  }
+
+  // Rule 3.6 — FX fee asociado a payment internacional
+  //
+  // Caso: FX fees Global66 que tienen cost_category='direct_member' pero
+  // beneficiary_name puede ser null o "Costo tipo de cambio (Andrés Colombia
+  // nómina marzo)". Si la description menciona explícitamente nómina/payroll
+  // + payment_provider_slug es fintech internacional → cost-of-payroll.
+  if (
+    input.costCategory === 'direct_member' &&
+    input.rawDescription &&
+    /(?:tipo\s+de\s+cambio|fx\s+fee|comisi[oó]n\s+(?:envio|env[ií]o|transfer|wire))/i.test(input.rawDescription) &&
+    /n[oó]mina|payroll|sueldo|salario|colaborador/i.test(input.rawDescription)
+  ) {
+    return {
+      category: 'labor_cost_external',
+      confidence: 'medium',
+      matchedRule: 'FX_FEE_COST_OF_PAYROLL',
+      evidence: {
+        ...evidence,
+        raw_description: input.rawDescription,
+        reason: 'FX fee con cost_category=direct_member y description mencionando nómina/payroll → cost-of-payroll (no overhead bancario)'
       }
     }
   }

--- a/src/lib/finance/economic-category/writer-integration.ts
+++ b/src/lib/finance/economic-category/writer-integration.ts
@@ -1,0 +1,225 @@
+import 'server-only'
+
+import { randomUUID } from 'node:crypto'
+
+import type { PoolClient } from 'pg'
+
+import { runGreenhousePostgresQuery } from '@/lib/postgres/client'
+
+import {
+  resolveExpenseEconomicCategory,
+  resolveIncomeEconomicCategory,
+  type ResolveExpenseInput,
+  type ResolveIncomeInput
+} from './resolver'
+import type { ExpenseEconomicCategory, IncomeEconomicCategory } from './types'
+
+/**
+ * TASK-768 — Helper de integración write-time para canonical writers.
+ *
+ * Cualquier writer canónico que crea expenses / income debe invocar este
+ * helper ANTES del INSERT para resolver `economic_category` con confidence
+ * canónica (no solo el trigger PG transparente que mapea desde expense_type).
+ *
+ * Sinergia con TASK-765 path canónico (payment_orders → recordExpensePayment):
+ * el resolver tiene acceso a member_id, supplier_id, cost_category, raw
+ * description — datos que el trigger transparente NO puede usar. Resultado:
+ * confidence=high para casos identity-resolved, no fallback genérico.
+ *
+ * Defense-in-depth: si un writer olvida invocar este helper, el trigger PG
+ * `populate_economic_category_default` igual poblará la columna con un
+ * default razonable (transparent map). Pero `confidence=transparent_map`
+ * vs `confidence=high` es distinguible en el audit log.
+ */
+
+interface WriterClient {
+  query: (text: string, params?: unknown[]) => Promise<unknown>
+}
+
+/**
+ * Resuelve economic_category para un nuevo expense + persiste audit log +
+ * enqueue manual queue si confidence baja. Retorna la categoría que el
+ * writer debe anexar al INSERT.
+ *
+ * Patrón de uso desde un writer canónico:
+ *
+ * ```ts
+ * const { category, confidence, matchedRule } =
+ *   await resolveAndPersistExpenseEconomicCategory({
+ *     expenseId,
+ *     resolverInput: { ... },
+ *     client
+ *   })
+ *
+ * // Pass category to INSERT statement
+ * await client.query('INSERT INTO greenhouse_finance.expenses (..., economic_category) VALUES (..., $N)', [..., category])
+ * ```
+ *
+ * El trigger BEFORE INSERT respeta valores ya poblados (no sobrescribe), por
+ * lo que el resolver tiene precedencia sobre el transparent map.
+ */
+export const resolveAndPersistExpenseEconomicCategory = async (params: {
+  expenseId: string
+  resolverInput: ResolveExpenseInput
+  client?: WriterClient
+}): Promise<{
+  category: ExpenseEconomicCategory
+  confidence: 'high' | 'medium' | 'low' | 'manual_required'
+  matchedRule: string
+}> => {
+  const result = await resolveExpenseEconomicCategory(params.resolverInput)
+
+  const evidence = JSON.stringify(result.evidence)
+  const needsManualReview = result.confidence === 'low' || result.confidence === 'manual_required'
+
+  await persistResolutionLog({
+    targetKind: 'expense',
+    targetId: params.expenseId,
+    resolvedCategory: result.category,
+    matchedRule: result.matchedRule,
+    confidence: result.confidence,
+    evidenceJson: evidence,
+    resolvedBy: 'canonical-writer',
+    client: params.client
+  })
+
+  if (needsManualReview) {
+    await enqueueManualReview({
+      targetKind: 'expense',
+      targetId: params.expenseId,
+      candidateCategory: result.category,
+      candidateConfidence: result.confidence,
+      candidateRule: result.matchedRule,
+      candidateEvidence: evidence,
+      client: params.client
+    })
+  }
+
+  return {
+    category: result.category,
+    confidence: result.confidence,
+    matchedRule: result.matchedRule
+  }
+}
+
+/**
+ * Mirror para income.
+ */
+export const resolveAndPersistIncomeEconomicCategory = async (params: {
+  incomeId: string
+  resolverInput: ResolveIncomeInput
+  client?: WriterClient
+}): Promise<{
+  category: IncomeEconomicCategory
+  confidence: 'high' | 'medium' | 'low' | 'manual_required'
+  matchedRule: string
+}> => {
+  const result = await resolveIncomeEconomicCategory(params.resolverInput)
+
+  const evidence = JSON.stringify(result.evidence)
+  const needsManualReview = result.confidence === 'low' || result.confidence === 'manual_required'
+
+  await persistResolutionLog({
+    targetKind: 'income',
+    targetId: params.incomeId,
+    resolvedCategory: result.category,
+    matchedRule: result.matchedRule,
+    confidence: result.confidence,
+    evidenceJson: evidence,
+    resolvedBy: 'canonical-writer',
+    client: params.client
+  })
+
+  if (needsManualReview) {
+    await enqueueManualReview({
+      targetKind: 'income',
+      targetId: params.incomeId,
+      candidateCategory: result.category,
+      candidateConfidence: result.confidence,
+      candidateRule: result.matchedRule,
+      candidateEvidence: evidence,
+      client: params.client
+    })
+  }
+
+  return {
+    category: result.category,
+    confidence: result.confidence,
+    matchedRule: result.matchedRule
+  }
+}
+
+const persistResolutionLog = async (params: {
+  targetKind: 'expense' | 'income'
+  targetId: string
+  resolvedCategory: string
+  matchedRule: string
+  confidence: string
+  evidenceJson: string
+  resolvedBy: string
+  client?: WriterClient
+}): Promise<void> => {
+  const sql = `INSERT INTO greenhouse_finance.economic_category_resolution_log
+       (log_id, target_kind, target_id, resolved_category, matched_rule,
+        confidence, evidence_json, resolved_by, batch_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL)`
+
+  const args: unknown[] = [
+    `ecr-${randomUUID()}`,
+    params.targetKind,
+    params.targetId,
+    params.resolvedCategory,
+    params.matchedRule,
+    params.confidence,
+    params.evidenceJson,
+    params.resolvedBy
+  ]
+
+  if (params.client) {
+    await params.client.query(sql, args)
+  } else {
+    await runGreenhousePostgresQuery(sql, args)
+  }
+}
+
+const enqueueManualReview = async (params: {
+  targetKind: 'expense' | 'income'
+  targetId: string
+  candidateCategory: string
+  candidateConfidence: string
+  candidateRule: string
+  candidateEvidence: string
+  client?: WriterClient
+}): Promise<void> => {
+  const sql = `INSERT INTO greenhouse_finance.economic_category_manual_queue
+       (queue_id, target_kind, target_id, candidate_category,
+        candidate_confidence, candidate_rule, candidate_evidence)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (target_kind, target_id) DO UPDATE SET
+       candidate_category = EXCLUDED.candidate_category,
+       candidate_confidence = EXCLUDED.candidate_confidence,
+       candidate_rule = EXCLUDED.candidate_rule,
+       candidate_evidence = EXCLUDED.candidate_evidence,
+       updated_at = NOW()`
+
+  const args: unknown[] = [
+    `ecq-${randomUUID()}`,
+    params.targetKind,
+    params.targetId,
+    params.candidateCategory,
+    params.candidateConfidence,
+    params.candidateRule,
+    params.candidateEvidence
+  ]
+
+  if (params.client) {
+    await params.client.query(sql, args)
+  } else {
+    await runGreenhousePostgresQuery(sql, args)
+  }
+}
+
+/**
+ * Re-export tipo PoolClient para que canonical writers tengan tipo correcto.
+ */
+export type { PoolClient }

--- a/src/lib/finance/factoring.ts
+++ b/src/lib/finance/factoring.ts
@@ -6,6 +6,7 @@ import type { PoolClient } from 'pg'
 
 import { withGreenhousePostgresTransaction } from '@/lib/postgres/client'
 import { assertFinanceSlice2PostgresReady } from '@/lib/finance/postgres-store-slice2'
+import { resolveAndPersistExpenseEconomicCategory } from '@/lib/finance/economic-category/writer-integration'
 import { FinanceValidationError, toNumber, normalizeString, roundCurrency } from '@/lib/finance/shared'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -71,6 +72,24 @@ const insertExpenseInTransaction = async (
     actorUserId: string | null
   }
 ): Promise<void> => {
+  // TASK-768 — resolver canónico: factoring fees con supplier marcado partner
+  // → financial_settlement (rule SUPPLIER_LOOKUP_PARTNER). Sin partner →
+  // ACCOUNTING_TYPE_AMBIGUOUS_FALLBACK con manual queue.
+  const resolution = await resolveAndPersistExpenseEconomicCategory({
+    expenseId,
+    resolverInput: {
+      beneficiaryName: supplierName,
+      beneficiarySupplierId: supplierId,
+      rawDescription: description,
+      sourceKind: 'factoring',
+      accountingType: expenseType,
+      costCategory: 'operational',
+      amount,
+      currency: 'CLP'
+    },
+    client: client as { query: (text: string, params?: unknown[]) => Promise<unknown> }
+  })
+
   await client.query(
     `INSERT INTO greenhouse_finance.expenses (
       expense_id, client_id, expense_type, description, currency,
@@ -87,7 +106,7 @@ const insertExpenseInTransaction = async (
       is_reconciled,
       cost_category, cost_is_direct, allocated_client_id,
       direct_overhead_scope, direct_overhead_kind, direct_overhead_member_id,
-      notes, created_by_user_id,
+      notes, created_by_user_id, economic_category,
       created_at, updated_at
     )
     VALUES (
@@ -105,13 +124,13 @@ const insertExpenseInTransaction = async (
       FALSE,
       'operational', FALSE, NULL,
       NULL, NULL, NULL,
-      NULL, $10,
+      NULL, $10, $11,
       CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
     )`,
     [
       expenseId, clientId, expenseType, description,
       amount, paymentDate, paymentReference,
-      supplierId, supplierName, actorUserId
+      supplierId, supplierName, actorUserId, resolution.category
     ]
   )
 }

--- a/src/lib/finance/postgres-store-slice2.ts
+++ b/src/lib/finance/postgres-store-slice2.ts
@@ -22,6 +22,10 @@ import {
 import { parsePersistedIncomeTaxSnapshot } from '@/lib/finance/income-tax-snapshot'
 import { parsePersistedExpenseTaxSnapshot } from '@/lib/finance/expense-tax-snapshot'
 import { resolveAutoAllocation, type AutoAllocationInput } from '@/lib/finance/auto-allocation-rules'
+import {
+  resolveAndPersistExpenseEconomicCategory,
+  resolveAndPersistIncomeEconomicCategory
+} from '@/lib/finance/economic-category/writer-integration'
 import { ensureOrganizationForClient } from '@/lib/account-360/organization-identity'
 import type { ChileTaxSnapshot } from '@/lib/tax/chile'
 
@@ -1415,6 +1419,20 @@ export const createFinanceIncomeInPostgres = async ({
   await assertFinanceSlice2PostgresReady()
 
   const run = async (client: PoolClient) => {
+    // TASK-768 — resolver canónico income en write-time.
+    const incomeEconomicCategoryResolution = await resolveAndPersistIncomeEconomicCategory({
+      incomeId,
+      resolverInput: {
+        payerName: clientName ?? null,
+        payerClientProfileId: clientProfileId,
+        rawDescription: description,
+        accountingType: incomeType,
+        amount: totalAmount,
+        currency
+      },
+      client
+    })
+
     const rows = await queryRows<PostgresIncomeRow>(
       `
         INSERT INTO greenhouse_finance.income (
@@ -1429,7 +1447,7 @@ export const createFinanceIncomeInPostgres = async ({
           po_number, hes_number, service_line, income_type,
           is_reconciled,
           partner_id, partner_name, partner_share_percent, partner_share_amount, net_after_partner,
-          notes, created_by_user_id,
+          notes, created_by_user_id, economic_category,
           created_at, updated_at
         )
         VALUES (
@@ -1444,7 +1462,7 @@ export const createFinanceIncomeInPostgres = async ({
           $31, $32, $33, $34,
           FALSE,
           $35, $36, $37, $38, $39,
-          $40, $41,
+          $40, $41, $42,
           CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         )
         RETURNING *
@@ -1460,7 +1478,7 @@ export const createFinanceIncomeInPostgres = async ({
         quotationId, contractId, sourceHesId, purchaseOrderId, hesId,
         poNumber, hesNumber, serviceLine, incomeType,
         partnerId, partnerName, partnerSharePercent, partnerShareAmount, netAfterPartner,
-        notes, actorUserId
+        notes, actorUserId, incomeEconomicCategoryResolution.category
       ],
       client
     )
@@ -2150,6 +2168,27 @@ export const createFinanceExpenseInPostgres = async ({
   await assertFinanceSlice2PostgresReady()
 
   const run = async (client: PoolClient) => {
+    // TASK-768 — resolver canónico invocado en write-time.
+    // Sinergia con TASK-765 path canónico: el resolver tiene acceso a
+    // member_id, supplier_id, cost_category, raw description — datos que
+    // el trigger transparente NO puede usar. Resultado: confidence=high
+    // para casos identity-resolved, no fallback genérico.
+    const economicCategoryResolution = await resolveAndPersistExpenseEconomicCategory({
+      expenseId,
+      resolverInput: {
+        beneficiaryName: supplierName ?? memberName ?? null,
+        beneficiaryMemberId: memberId,
+        beneficiarySupplierId: supplierId,
+        rawDescription: description,
+        sourceKind: sourceType,
+        accountingType: expenseType,
+        costCategory: costCategory ?? null,
+        amount: totalAmount,
+        currency
+      },
+      client
+    })
+
     const rows = await queryRows<PostgresExpenseRow>(
       `
         INSERT INTO greenhouse_finance.expenses (
@@ -2171,7 +2210,7 @@ export const createFinanceExpenseInPostgres = async ({
           direct_overhead_scope, direct_overhead_kind, direct_overhead_member_id,
           receipt_date, purchase_type, vat_unrecoverable_amount, vat_fixed_assets_amount, vat_common_use_amount,
           dte_type_code, dte_folio, exempt_amount, other_taxes_amount, withholding_amount,
-          notes, created_by_user_id,
+          notes, created_by_user_id, economic_category,
           created_at, updated_at
         )
         VALUES (
@@ -2193,7 +2232,7 @@ export const createFinanceExpenseInPostgres = async ({
           $57, $58, $59,
           $60::date, $61, $62, $63, $64,
           $65, $66, $67, $68, $69,
-          $70, $71,
+          $70, $71, $72,
           CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
         )
         RETURNING *
@@ -2216,7 +2255,7 @@ export const createFinanceExpenseInPostgres = async ({
         directOverheadScope, directOverheadKind, directOverheadMemberId,
         receiptDate, purchaseType, vatUnrecoverableAmount, vatFixedAssetsAmount, vatCommonUseAmount,
         dteTypeCode, dteFolio, exemptAmount, otherTaxesAmount, withholdingAmount,
-        notes, actorUserId
+        notes, actorUserId, economicCategoryResolution.category
       ],
       client
     )


### PR DESCRIPTION
## Summary

Cierra el gap arquitectónico entre **TASK-765** (path canónico payment_orders → markPaid → recordExpensePayment) y **TASK-768** (dimensión analítica). Hasta ahora cada nuevo expense creado por canonical writers recibía clasificación del trigger PG transparente — limitado a mapping desde `expense_type`. Con este cambio los writers invocan el **resolver TS canónico** que tiene acceso a member_id, supplier_id, cost_category, raw description.

## KPI Nómina abril 2026

| | Pre-fix | Post-V1.1 |
|---|---|---|
| Nómina total | $1.030.082 | **$3.750.950** (+$2.72M) ✅ |
| - labor_cost_internal | — | $895.448 (Valentina + Humberly + ECG) |
| - labor_cost_external | — | $2.855.502 (Daniela España + Andrés Colombia + Melkin Deel + FX fee Daniela) |
| Fiscal | $4.308.114 | $4.584.337 (+$276k Previred) |
| Proveedores | $5.321.241 | $2.647.004 (-$2.67M → Nómina canónica) |
| Total Pagado | $11.143.931 | $11.143.931 ✅ preservado |
| economic_category_unresolved | 161+19 | **0** ✅ |

## Cambios

- **Resolver V1.1** con 4 reglas nuevas (DIRECT_MEMBER_COST_CATEGORY × 2, FX_FEE_COST_OF_PAYROLL, SII_TAX para regulator regex)
- **Helper write-time** `resolveAndPersistExpenseEconomicCategory` reusable por cualquier writer
- **3 canonical writers migrados**: `createFinanceExpenseInPostgres`, `createFinanceIncomeInPostgres`, `factoring.ts`
- **2 migrations retroactivas**: SII tax fix + international collaborators clear
- **Helper `looksLikeHumanName`**: regex CORPORATE_BENEFICIARY + KNOWN_BRANDS evita false positives

## Defense-in-depth (7 capas)

1. Trigger PG `populate_default` (safety net)
2. Resolver TS write-time (canonical confidence)
3. CHECK NOT VALID + `canonical_values` VALIDATED
4. Audit log append-only con previous_category
5. Manual queue para confidence baja
6. Reliability signals `economic_category_unresolved`
7. Lint rule `no-untokenized-expense-type-for-analytics`

## Verificación

- `pnpm test`: ✅ **533 files / 3010 tests verdes** (+5 vs baseline TASK-768)
- `pnpm tsc --noEmit`: ✅ 0 errors
- `pnpm lint`: ✅ 0 errors / 318 warnings preexistentes
- DB live abril 2026: payrollClp=$3.75M, total preservado, unresolved=0
- Universal column-parity test (TASK-765): 19/19 verdes
- Tests Daniela España, Andrés Colombia, FX fee, Adobe corporate exclusion, SII→tax

🤖 Generated with [Claude Code](https://claude.com/claude-code)