### PR TITLE
Hotfix TASK-857 GitHub webhook ping

### DIFF
--- a/src/lib/release/github-webhook-handler.test.ts
+++ b/src/lib/release/github-webhook-handler.test.ts
@@ -110,6 +110,32 @@ describe('github release webhook handler', () => {
     expect(mocks.query).not.toHaveBeenCalled()
   })
 
+  it('accepts signed GitHub ping deliveries without release persistence', async () => {
+    const rawBody = JSON.stringify({
+      zen: 'Design for failure.',
+      repository: { full_name: 'efeoncepro/greenhouse-eo' }
+    })
+
+    const result = await handleGithubReleaseWebhookRequest(
+      buildWebhookRequest({
+        rawBody,
+        eventName: 'ping'
+      })
+    )
+
+    expect(result.status).toBe(202)
+    expect(result.body).toMatchObject({
+      ok: true,
+      code: 'ping_accepted',
+      deliveryId: 'delivery-123',
+      repositoryFullName: 'efeoncepro/greenhouse-eo'
+    })
+    expect(mocks.ensureWebhookSchema).not.toHaveBeenCalled()
+    expect(mocks.insertInboxEvent).not.toHaveBeenCalled()
+    expect(mocks.query).not.toHaveBeenCalled()
+    expect(mocks.reconcileGithubReleaseWebhookEvent).not.toHaveBeenCalled()
+  })
+
   it('persists a signed delivery, reconciles it and returns accepted', async () => {
     const rawBody = JSON.stringify({
       action: 'completed',

--- a/src/lib/release/github-webhook-ingestion.ts
+++ b/src/lib/release/github-webhook-ingestion.ts
@@ -25,6 +25,7 @@ export const GITHUB_RELEASE_PROVIDER_CODE = 'github'
 export const GITHUB_RELEASE_WEBHOOK_MAX_BYTES = 2_000_000
 
 export const GITHUB_RELEASE_WEBHOOK_EVENTS = [
+  'ping',
   'workflow_run',
   'workflow_job',
   'deployment_status',
@@ -33,6 +34,7 @@ export const GITHUB_RELEASE_WEBHOOK_EVENTS = [
 ] as const
 
 type GithubReleaseWebhookEventName = (typeof GITHUB_RELEASE_WEBHOOK_EVENTS)[number]
+type GithubReleaseReconcilerEventName = Exclude<GithubReleaseWebhookEventName, 'ping'>
 
 export interface GithubReleaseWebhookResponse {
   status: number
@@ -88,6 +90,13 @@ export const handleGithubReleaseWebhookRequest = async (
     payload = parsed as Record<string, unknown>
   } catch {
     return response(400, 'invalid_json')
+  }
+
+  if (eventName === 'ping') {
+    return response(202, 'ping_accepted', {
+      deliveryId,
+      repositoryFullName: stringValue(asRecord(payload.repository)?.full_name)
+    })
   }
 
   await ensureWebhookSchema()
@@ -173,7 +182,7 @@ export const buildGithubDeliveryIdempotencyKey = (deliveryId: string): string =>
 
 export const normalizeGithubReleaseWebhook = (params: {
   deliveryId: string
-  eventName: GithubReleaseWebhookEventName
+  eventName: GithubReleaseReconcilerEventName
   payload: Record<string, unknown>
 }): Omit<NormalizedGithubReleaseWebhookEvent, 'inboxEventId'> => {
   const payload = params.payload


### PR DESCRIPTION
Promotes signed GitHub webhook ping acceptance so the real repository webhook can be configured and tested cleanly.\n\nScope guard:\n- Only src/lib/release/github-webhook-ingestion.ts and its handler test.\n- No Payroll/PDF files included.\n\nValidation:\n- pnpm test -- src/lib/release/github-webhook-handler.test.ts src/lib/release/github-webhook-ingestion.test.ts src/lib/release/github-webhook-reconciler.test.ts\n- pnpm exec tsc --noEmit --pretty false\n- pre-push pnpm lint + pnpm tsc --noEmit