### PR TITLE
ci: Claude PR assistant workflow (Sonnet, gated, comment-only)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,15 +26,23 @@ on:
   pull_request_review_comment:
     types: [created]
 
-# Una corrida por hilo de comentario; cancelar en duplicados ahorra API.
+# Dedup: si el MISMO evento de comentario se re-entrega, el run nuevo cancela
+# el anterior. Comentarios distintos => grupos distintos => corren independientes
+# (cada @claude es una petición propia, no se deben cancelar entre sí).
 concurrency:
-  group: claude-assistant-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id }}
-  cancel-in-progress: false
+  group: claude-assistant-${{ github.event.comment.id }}
+  cancel-in-progress: true
 
 jobs:
   claude:
-    # Gate de costo: solo en menciones explícitas @claude.
-    if: contains(github.event.comment.body, '@claude')
+    # Doble gate (costo + abuso):
+    #  1. mención explícita @claude
+    #  2. autor con relación de confianza al repo (OWNER/MEMBER/COLLABORATOR)
+    #     => un tercero que comente NO puede gastar la API key ni hacer que el
+    #     bot escriba con permisos issues/pull-requests write.
+    if: >
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,54 @@
+# Claude PR assistant — responde a menciones @claude en PRs/issues.
+#
+# Diseño acotado por costo + seguridad (decisión 2026-05-24):
+#   - Modelo: Sonnet (~5x más barato que Opus para review). Alias `sonnet`
+#     resuelve siempre al último Sonnet; pin a un id específico si se quiere
+#     costo 100% predecible.
+#   - Gated: solo corre cuando el comentario contiene '@claude' (el `if`
+#     evita levantar el runner + gastar API en cada comentario del repo).
+#   - Comment-only: `permissions.contents: read` (NO write) → Claude puede
+#     leer el repo y comentar/revisar, pero NO puede pushear commits.
+#   - `--max-turns` acota el loop agéntico (principal driver de tokens).
+#   - Prompt caching: lo maneja el runtime de Claude Code automáticamente.
+#
+# REQUISITO operador-side antes de que funcione:
+#   - Crear el secret de repo `ANTHROPIC_API_KEY` (Settings > Secrets and
+#     variables > Actions). Es billing aparte (API Anthropic por uso).
+#   - Sin el secret, el workflow falla loud en el step de la action.
+#
+# NO interactúa con el flujo de release ni con deploys: es read + comment.
+
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# Una corrida por hilo de comentario; cancelar en duplicados ahorra API.
+concurrency:
+  group: claude-assistant-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    # Gate de costo: solo en menciones explícitas @claude.
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # NO write — comment-only, no puede pushear
+      pull-requests: write # comentar / revisar el PR
+      issues: write # responder en el hilo (issue_comment)
+    steps:
+      - name: Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Sin `prompt` fijo → Claude actúa según el texto del comentario
+          # @claude (modo interactivo). El usuario controla el scope por
+          # invocación (ej. "@claude revisá X" / "@claude ¿por qué Y?").
+          claude_args: |
+            --model sonnet
+            --max-turns 15


### PR DESCRIPTION
## Summary

Wirea `@claude` como asistente/reviewer en PRs e issues vía `anthropics/claude-code-action@v1`, **acotado por costo + seguridad** desde el día 1:

- **Modelo Sonnet** (`--model sonnet`) → ~5× más barato que Opus para review. Pin a un id específico si se quiere costo 100% predecible.
- **Gated**: `if: contains(github.event.comment.body, '@claude')` → no levanta runner ni gasta API en cada comentario.
- **Comment-only**: `permissions.contents: read` (NO write) → Claude lee el repo y comenta/revisa, **no puede pushear commits**. No toca el flujo de release ni deploys.
- **`--max-turns 15`** acota el loop agéntico (principal driver de tokens). Prompt caching lo maneja el runtime automáticamente.
- **Sin `prompt` fijo** → modo interactivo: actúa según el texto del comentario `@claude` (el usuario controla el scope por invocación).

Estimación de costo con esta config: ~**$10-30/mes** para 20-50 reviews/mes (driver oculto = el CLAUDE.md grande; mitigado por gating + caching + Sonnet).

## ⚠️ Requisito operador-side (antes de que funcione)

Crear el secret de repo **`ANTHROPIC_API_KEY`** (Settings → Secrets and variables → Actions). Es billing aparte (API Anthropic por uso). Sin el secret, el workflow falla loud en el step de la action — no rompe nada más.

## Notas

- No usa `pnpm`/Node en el job → la regla canónica de ordering pnpm/setup-node no aplica.
- Codex queda fuera de alcance (no hay action oficial turnkey); sigue como sesión interactiva.

## Test plan

- [ ] Crear el secret `ANTHROPIC_API_KEY`.
- [ ] Mergear a develop.
- [ ] Comentar `@claude revisá este PR` en un PR de prueba → verificar que responde y que NO puede pushear (solo comenta).
- [ ] Confirmar que comentarios sin `@claude` NO disparan el workflow.

https://claude.ai/code/session_014peg6FYLPzB2ihfFDCBPcv

---
_Generated by [Claude Code](https://claude.ai/code/session_014peg6FYLPzB2ihfFDCBPcv)_