### PR TITLE
fix(growth-forms): initialize required select defaults

### DIFF
--- a/src/growth-forms-renderer/__tests__/renderer.test.ts
+++ b/src/growth-forms-renderer/__tests__/renderer.test.ts
@@ -433,6 +433,41 @@ describe('growth-forms-renderer · FormRenderer', () => {
     expect(root.querySelector('[role="option"][aria-selected="true"]')?.textContent).toBe('1 - 10')
   })
 
+  it('initializes required selects without a blank option to the displayed first option', async () => {
+    const fetchImpl = okFetch()
+
+    const { root } = mountInto(staticContractFixture({
+      styleVariant: 'diagnostic_premium',
+      fields: [
+        {
+          key: 'analysisLanguage',
+          type: 'select',
+          label: 'Idioma del análisis',
+          required: true,
+          options: [
+            { value: 'es-CL', label: 'Español (Chile / LatAm)' },
+            { value: 'en-US', label: 'English (US)' },
+          ],
+        },
+      ],
+      consent: undefined,
+    }), fetchImpl)
+
+    const trigger = root.querySelector<HTMLButtonElement>('[name="analysisLanguage"].ghf-select-trigger')!
+
+    expect(trigger.textContent).toContain('Español (Chile / LatAm)')
+
+    root.querySelector('form')!.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }))
+
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1))
+
+    const calls = (fetchImpl as unknown as { mock: { calls: Array<[string, { body: string }]> } }).mock.calls
+    const body = JSON.parse(calls[0][1].body)
+
+    expect(body.fields.analysisLanguage).toBe('es-CL')
+    expect(root.querySelector('[data-ghf-summary]')).toBeNull()
+  })
+
   it('uses contract-provided field required copy when present', () => {
     const { root } = mountInto(staticContractFixture({
       fields: [{ key: 'firstName', type: 'text', label: 'Nombre', required: true }],

--- a/src/growth-forms-renderer/renderer.ts
+++ b/src/growth-forms-renderer/renderer.ts
@@ -155,7 +155,15 @@ export class FormRenderer {
     this.telemetry = createTelemetryEmitter(opts.root, this.contract.telemetryPolicy, base)
 
     for (const field of this.contract.fields) {
-      this.values[field.key] = field.type === 'consent' || field.type === 'checkbox' ? false : ''
+      if (field.type === 'consent' || field.type === 'checkbox') {
+        this.values[field.key] = false
+      } else if (field.type === 'multiselect') {
+        this.values[field.key] = []
+      } else if (field.type === 'select' && field.required && !(field.options?.some(option => option.value === '') ?? false)) {
+        this.values[field.key] = field.options?.[0]?.value ?? ''
+      } else {
+        this.values[field.key] = ''
+      }
     }
 
     // Restaura un borrador PII-safe (sin cédula/consent) si existe (TASK-1256 Slice 1d).


### PR DESCRIPTION
## Summary\n- Initialize required select fields without a blank option to the first displayed option.\n- Covers the premium Growth Forms select case where the UI showed a default language but internal validation still had an empty value.\n\n## Verification\n- pnpm exec vitest run src/growth-forms-renderer/__tests__/renderer.test.ts\n- pnpm renderer:build\n- pnpm typecheck\n- pre-push local:check (lint + typecheck)