### PR TITLE
feat(growth-forms): polish grader intake controls

### DIFF
--- a/scripts/growth/activate-grader-premium-intake-contract.ts
+++ b/scripts/growth/activate-grader-premium-intake-contract.ts
@@ -8,8 +8,8 @@ import 'server-only'
  * - preserva validation/namePolicy/emailPolicy, consent, security, policies y destinations
  * - cambia solo el contrato browser-safe del form:
  *   - `style_variant=diagnostic_premium`
- *   - `ui_policy.composition=multi_step_light` con 5 pasos breves, entrega primero
- *   - labels/placeholders/help copy humanos para una experiencia enterprise
+ *   - `ui_policy.composition=multi_step_light` con 5 pantallas breves
+ *   - labels/placeholders/help copy y opciones guiadas para una experiencia enterprise
  *   - `successBehavior.tokenizedReport.statusPathTemplate` para el handoff Think
  * - publica una version nueva y depreca la anterior.
  *
@@ -24,7 +24,7 @@ import {
   getFormDefinitionByKey,
   getPublishedVersionBySlug,
   listDestinationsForVersion,
-  listHostSurfaces
+  listHostSurfaces,
 } from '@/lib/growth/forms/store'
 import { applyGreenhousePostgresProfile, loadGreenhouseToolEnv } from '../lib/load-greenhouse-tool-env'
 import { preserveFormVersionFields } from '../lib/preserve-form-version-fields'
@@ -44,28 +44,28 @@ const STEPS = [
   {
     key: 'delivery',
     label: 'Entrega',
-    fieldKeys: ['firstName', 'lastName', 'email']
+    fieldKeys: ['firstName', 'lastName', 'email'],
   },
   {
     key: 'brand',
     label: 'Marca',
-    fieldKeys: ['brandName', 'websiteUrl']
+    fieldKeys: ['brandName', 'websiteUrl'],
   },
   {
     key: 'market',
     label: 'Mercado',
-    fieldKeys: ['market', 'locale', 'category']
+    fieldKeys: ['market', 'locale', 'category'],
   },
   {
     key: 'context',
     label: 'Contexto',
-    fieldKeys: ['competitorsDeclared', 'industry']
+    fieldKeys: ['competitorsDeclared', 'industry'],
   },
   {
     key: 'refine',
     label: 'Confirmar',
-    fieldKeys: ['persona', 'companySize', 'mainChallenge', 'consent']
-  }
+    fieldKeys: ['persona', 'companySize', 'mainChallenge', 'consent'],
+  },
 ] as const
 
 const FIELD_UPDATES: Record<string, Record<string, unknown>> = {
@@ -73,111 +73,154 @@ const FIELD_UPDATES: Record<string, Record<string, unknown>> = {
     label: 'Nombre de la marca',
     placeholder: 'ej. Efeonce',
     autocomplete: 'organization',
-    maxLength: 120
+    maxLength: 120,
   },
   websiteUrl: {
     label: 'Sitio web',
     placeholder: 'ej. https://tuempresa.com',
     autocomplete: 'url',
-    inputMode: 'url'
+    inputMode: 'url',
   },
   market: {
+    type: 'select',
     label: 'Mercado principal',
-    placeholder: 'ej. Chile, Mexico, LatAm B2B',
-    maxLength: 80
+    placeholder: 'Selecciona mercado',
+    options: [
+      { value: 'Chile', label: 'Chile' },
+      { value: 'Mexico', label: 'Mexico' },
+      { value: 'Colombia', label: 'Colombia' },
+      { value: 'Peru', label: 'Peru' },
+      { value: 'LatAm', label: 'LatAm' },
+      { value: 'Estados Unidos', label: 'Estados Unidos' },
+      { value: 'Global', label: 'Global' },
+    ],
   },
   locale: {
     type: 'select',
-    label: 'Idioma del análisis',
-    placeholder: 'Selecciona idioma/región',
+    label: 'Idioma del analisis',
+    placeholder: 'Selecciona idioma/region',
     options: [
-      { value: 'es-CL', label: 'Español (Chile / LatAm)' },
-      { value: 'en-US', label: 'Inglés (Estados Unidos)' }
-    ]
+      { value: 'es-CL', label: 'Espanol (Chile / LatAm)' },
+      { value: 'en-US', label: 'Ingles (Estados Unidos)' },
+    ],
   },
   category: {
-    label: 'Categoría donde compites',
-    placeholder: 'ej. banca, retail, educación superior',
-    maxLength: 140
+    type: 'select',
+    label: 'Categoria donde compites',
+    placeholder: 'Selecciona categoria',
+    options: [
+      { value: 'Agencia o consultoria de crecimiento', label: 'Agencia / consultoria de crecimiento' },
+      { value: 'SaaS o software B2B', label: 'SaaS / software B2B' },
+      { value: 'Retail o ecommerce', label: 'Retail / ecommerce' },
+      { value: 'Banca, seguros o fintech', label: 'Banca / seguros / fintech' },
+      { value: 'Educacion', label: 'Educacion' },
+      { value: 'Salud', label: 'Salud' },
+      { value: 'Turismo u hoteleria', label: 'Turismo / hoteleria' },
+      { value: 'Inmobiliaria o construccion', label: 'Inmobiliaria / construccion' },
+      { value: 'Servicios profesionales', label: 'Servicios profesionales' },
+      { value: 'Consumo masivo', label: 'Consumo masivo' },
+      { value: 'Tecnologia o telecomunicaciones', label: 'Tecnologia / telecomunicaciones' },
+      { value: 'Otra categoria', label: 'Otra categoria' },
+    ],
   },
   competitorsDeclared: {
-    type: 'textarea',
+    type: 'multiselect',
     label: 'Competidores de referencia',
-    placeholder: 'ej. competidor regional, alternativa local, referente global',
-    maxLength: 280
+    placeholder: 'Escribe una marca y presiona Enter',
+    freeEntry: true,
+    maxItems: 5,
+    maxLength: 80,
   },
   firstName: {
     label: 'Nombre',
-    placeholder: 'ej. Paula',
     autocomplete: 'given-name',
-    maxLength: 80
+    maxLength: 80,
   },
   lastName: {
     label: 'Apellido',
-    placeholder: 'ej. Reyes',
     autocomplete: 'family-name',
-    maxLength: 80
+    maxLength: 80,
   },
   email: {
     label: 'Correo corporativo',
     placeholder: 'nombre@empresa.com',
     autocomplete: 'email',
     inputMode: 'email',
-    validator: 'corporate_email'
+    validator: 'corporate_email',
   },
   industry: {
+    type: 'select',
     label: 'Industria',
-    placeholder: 'ej. Servicios profesionales, tecnología, retail',
-    maxLength: 120
+    placeholder: 'Selecciona industria',
+    options: [
+      { value: 'Servicios profesionales', label: 'Servicios profesionales' },
+      { value: 'Tecnologia', label: 'Tecnologia' },
+      { value: 'Retail', label: 'Retail' },
+      { value: 'Finanzas', label: 'Finanzas' },
+      { value: 'Educacion', label: 'Educacion' },
+      { value: 'Salud', label: 'Salud' },
+      { value: 'Manufactura', label: 'Manufactura' },
+      { value: 'Inmobiliaria', label: 'Inmobiliaria' },
+      { value: 'Turismo', label: 'Turismo' },
+      { value: 'Sector publico', label: 'Sector publico' },
+      { value: 'Otra industria', label: 'Otra industria' },
+    ],
   },
   persona: {
-    label: 'Rol o comprador principal',
-    placeholder: 'ej. CMO, founder, gerente comercial',
-    maxLength: 120
+    type: 'select',
+    label: 'Quien usara el informe',
+    placeholder: 'Selecciona rol',
+    options: [
+      { value: 'Direccion general o founder', label: 'Direccion general / founder' },
+      { value: 'Marketing o CMO', label: 'Marketing / CMO' },
+      { value: 'Growth o performance', label: 'Growth / performance' },
+      { value: 'Comercial o ventas', label: 'Comercial / ventas' },
+      { value: 'Comunicaciones o PR', label: 'Comunicaciones / PR' },
+      { value: 'Producto o digital', label: 'Producto / digital' },
+      { value: 'Agencia o consultor', label: 'Agencia / consultor' },
+      { value: 'Otro equipo', label: 'Otro equipo' },
+    ],
   },
   companySize: {
-    label: 'Tamaño de empresa',
-    placeholder: 'ej. 51-200 personas',
-    maxLength: 80
+    type: 'select',
+    label: 'Tamano de empresa',
+    placeholder: 'Selecciona tamano',
+    options: [
+      { value: '1-10 personas', label: '1-10 personas' },
+      { value: '11-50 personas', label: '11-50 personas' },
+      { value: '51-200 personas', label: '51-200 personas' },
+      { value: '201-500 personas', label: '201-500 personas' },
+      { value: '501-1000 personas', label: '501-1000 personas' },
+      { value: 'Mas de 1000 personas', label: 'Mas de 1000 personas' },
+    ],
   },
   mainChallenge: {
-    label: 'Qué quieres entender o mejorar',
-    placeholder: 'ej. Entender por qué mi marca aparece poco en respuestas de IA.',
-    maxLength: 500
+    label: 'Que quieres entender o mejorar',
+    placeholder: 'Cuéntanos brevemente que te interesa revisar en la visibilidad de tu marca.',
+    maxLength: 500,
   },
   consent: {
-    label: 'Acepto que Efeonce use estos datos para generar y enviarme mi informe.'
-  }
+    label: 'Autorizo a Efeonce a usar estos datos para generar mi informe y enviarme el resultado.',
+  },
 }
 
 const COPY_UPDATES: Record<string, string> = {
-  submit: 'Generar mi informe',
-  'firstName.help': '',
-  'lastName.help': '',
-  'email.help': 'Mostramos el resultado aquí y dejamos una recuperación segura por correo.',
-  'consent.help': '',
-  'brandName.help': 'Usamos este nombre para buscar menciones y variaciones relevantes.',
+  submit: 'Generar mi analisis',
+  'brandName.help': 'Usamos este nombre para buscar menciones y variaciones de tu marca.',
   'websiteUrl.help': 'Opcional, pero ayuda a leer citabilidad y operabilidad del sitio correcto.',
-  'market.help': 'Territorio donde la IA debería entender, citar y comparar tu marca.',
+  'market.help': 'Define el contexto donde la IA deberia entender, comparar y citar tu marca.',
   'locale.help': 'Ajusta el idioma base de lectura del reporte.',
-  'category.help': 'Ayuda a interpretar la categoría correcta.',
-  'competitorsDeclared.help': 'Opcional: escribe 1 a 3 marcas. Si no las tienes claras, puedes omitir este paso.',
-  'industry.help': 'Opcional: nos ayuda a evitar comparaciones fuera de contexto.',
-  'persona.help': 'Opcional: ajusta el lenguaje del informe a quien tomará decisiones.',
-  'companySize.help': 'Opcional: calibra la recomendación según el tamaño de la organización.',
-  'mainChallenge.help': 'Opcional: una frase basta. Evita información sensible.',
-  'brandName.error.required': 'Escribe el nombre de la marca para iniciar el análisis.',
-  'market.error.required': 'Indica el mercado donde quieres evaluar la visibilidad.',
-  'locale.error.required': 'Elige el idioma base del informe.',
-  'category.error.required': 'Describe la categoría donde compite tu marca.',
-  'firstName.error.required': 'Escribe tu nombre para identificar la solicitud.',
-  'lastName.error.required': 'Escribe tu apellido para completar tus datos.',
-  'email.error.required': 'Escribe tu correo corporativo para recibir y recuperar el informe.',
-  'consent.error.required': 'Acepta el uso de datos para generar tu informe.'
+  'category.help': 'Evita comparaciones equivocadas: elige la categoria mas cercana a tu competencia real.',
+  'competitorsDeclared.help': 'Opcional: agrega hasta 5 marcas. Usa Enter o coma para crear cada chip.',
+  'industry.help': 'Opcional. Afina el benchmark cuando tu categoria existe en varias industrias.',
+  'persona.help': 'Opcional. Ajusta el lenguaje de recomendaciones al equipo que tomara decisiones.',
+  'companySize.help': 'Opcional. Ayuda a calibrar recomendaciones segun madurez y escala.',
+  'email.help': 'Usa tu correo corporativo para recibir y recuperar el informe.',
+  'mainChallenge.help': 'Opcional: una frase basta. Evita informacion sensible.',
 }
 
 const SUCCESS_MESSAGE =
-  'Solicitud recibida. Estamos consultando motores, citabilidad y contexto competitivo para preparar tu informe en pantalla.'
+  'Recibimos tu solicitud. Estamos preparando el analisis para mostrarte el reporte en pantalla.'
 
 const asObject = (value: unknown): Record<string, unknown> =>
   value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
@@ -214,17 +257,19 @@ const assertProductionRuntimeSupportsPremiumIntake = (): void => {
   const runtimeReady =
     renderer.includes("composition !== 'multi_step_light'") &&
     renderer.includes('buildTokenizedReportHandoff') &&
-    styles.includes('[data-ghf-style-variant="diagnostic_premium"]')
+    renderer.includes('renderTagMultiSelectControl') &&
+    styles.includes('[data-ghf-style-variant="diagnostic_premium"]') &&
+    styles.includes('.ghf-tag-input')
 
   if (runtimeReady) {
-    console.log(`\nRuntime guard: ${PRODUCTION_RUNTIME_REF} supports multi_step_light + premium + tokenized handoff.`)
+    console.log(`\nRuntime guard: ${PRODUCTION_RUNTIME_REF} supports multi_step_light + premium + chips + tokenized handoff.`)
 
     return
   }
 
   const message =
     `Premium grader activation would publish multi_step_light/diagnostic_premium/tokenizedReport, but ${PRODUCTION_RUNTIME_REF} ` +
-    'does not contain the renderer support. Release the code first, or pass --allow-runtime-pending only with an explicit rollback plan.'
+    'does not contain the renderer support for premium chips. Release the code first, or pass --allow-runtime-pending only with an explicit rollback plan.'
 
   if (!ALLOW_RUNTIME_PENDING) {
     console.error(`\nFAIL: ${message}`)
@@ -258,14 +303,14 @@ const withPremiumCopy = (copyRefs: unknown): Record<string, unknown> => {
 const withPremiumUiPolicy = (uiPolicy: unknown): Record<string, unknown> => ({
   ...asObject(uiPolicy),
   composition: 'multi_step_light',
-  steps: STEPS
+  steps: STEPS,
 })
 
 const withTokenizedSuccess = (successBehavior: unknown): Record<string, unknown> => ({
   ...asObject(successBehavior),
   kind: 'tokenized_report',
   message: SUCCESS_MESSAGE,
-  tokenizedReport: { statusPathTemplate: STATUS_PATH_TEMPLATE }
+  tokenizedReport: { statusPathTemplate: STATUS_PATH_TEMPLATE },
 })
 
 const main = async (): Promise<void> => {
@@ -324,15 +369,11 @@ const main = async (): Promise<void> => {
   console.log(`  style_variant objetivo: ${STYLE_VARIANT}`)
   console.log(`  composition actual    : ${asObject(current.ui_policy_json).composition ?? 'static'}`)
   console.log('  composition objetivo  : multi_step_light')
-  console.log(
-    `  campos                : ${Array.isArray(current.field_schema_json) ? current.field_schema_json.length : 0}`
-  )
+  console.log(`  campos                : ${Array.isArray(current.field_schema_json) ? current.field_schema_json.length : 0}`)
   console.log(`  destinos              : ${destinations.length}`)
 
   if (alreadyPremium) {
-    console.log(
-      '\nIdempotente: la version publicada vigente ya expone el contrato premium/progresivo del grader. Nada que hacer.'
-    )
+    console.log('\nIdempotente: la version publicada vigente ya expone el contrato premium/progresivo del grader. Nada que hacer.')
 
     return
   }
@@ -340,9 +381,10 @@ const main = async (): Promise<void> => {
   console.log('\nPlan:')
   console.log(`  - Clonar v${current.version}`)
   console.log(`  - Setear style_variant = ${STYLE_VARIANT}`)
-  console.log('  - Setear ui_policy.composition = multi_step_light con 5 pasos breves, entrega primero')
+  console.log('  - Setear ui_policy.composition = multi_step_light con 5 pantallas breves')
   console.log('  - Humanizar labels/placeholders/help copy de los campos del grader')
-  console.log('  - Cambiar competitorsDeclared de multiselect sin opciones a textarea opcional')
+  console.log('  - Convertir mercado/categoria/industria/rol/tamano en selectores gobernados')
+  console.log('  - Convertir competitorsDeclared en multiselect libre tipo chips')
   console.log('  - Añadir successBehavior.tokenizedReport.statusPathTemplate')
   console.log('  - Preservar validation/emailPolicy, ui_policy.security.captcha, consent y policies')
   console.log(`  - Copiar ${destinations.length} destino(s) de la version vigente`)
@@ -366,7 +408,7 @@ const main = async (): Promise<void> => {
     uiPolicy: nextUiPolicy,
     styleVariant: STYLE_VARIANT,
     successBehavior: nextSuccess,
-    createdBy: 'task-1327-grader-premium-intake-activation'
+    createdBy: 'task-1327-grader-premium-intake-activation',
   })
 
   console.log(`\nDraft creado: ${formVersionId}`)
@@ -381,7 +423,7 @@ const main = async (): Promise<void> => {
       deliveryMode: destination.delivery_mode,
       mapping: destination.mapping_json,
       consentRequirements: destination.consent_requirements_json,
-      retryPolicy: destination.retry_policy_json
+      retryPolicy: destination.retry_policy_json,
     })
 
     console.log(`Destino copiado: ${destination.destination_id} -> ${copied.destination_id}`)

--- a/src/growth-forms-renderer/__tests__/renderer.test.ts
+++ b/src/growth-forms-renderer/__tests__/renderer.test.ts
@@ -481,6 +481,45 @@ describe('growth-forms-renderer · FormRenderer', () => {
     expect(root.querySelector('[data-ghf-summary]')).toBeNull()
   })
 
+  it('renders free-entry multiselect fields as removable chips and submits string arrays', async () => {
+    const fetchImpl = okFetch()
+
+    const { root } = mountInto(staticContractFixture({
+      styleVariant: 'diagnostic_premium',
+      fields: [
+        {
+          key: 'competitorsDeclared',
+          type: 'multiselect',
+          label: 'Competidores de referencia',
+          placeholder: 'Escribe una marca y presiona Enter',
+          freeEntry: true,
+          maxItems: 3,
+        },
+      ],
+      consent: undefined,
+    }), fetchImpl)
+
+    const input = root.querySelector<HTMLInputElement>('[name="competitorsDeclared"].ghf-tag-entry')!
+
+    input.value = 'Marca A'
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, bubbles: true }))
+    input.value = 'Marca B'
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: ',', cancelable: true, bubbles: true }))
+
+    expect(Array.from(root.querySelectorAll('.ghf-tag-label')).map(node => node.textContent)).toEqual(['Marca A', 'Marca B'])
+
+    root.querySelector<HTMLButtonElement>('.ghf-tag-remove')!.click()
+    expect(Array.from(root.querySelectorAll('.ghf-tag-label')).map(node => node.textContent)).toEqual(['Marca B'])
+
+    root.querySelector('form')!.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }))
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1))
+
+    const calls = (fetchImpl as unknown as { mock: { calls: Array<[string, { body: string }]> } }).mock.calls
+    const body = JSON.parse(calls[0][1].body)
+
+    expect(body.fields.competitorsDeclared).toEqual(['Marca B'])
+  })
+
   it('uses contract-provided field required copy when present', () => {
     const { root } = mountInto(
       staticContractFixture({

--- a/src/growth-forms-renderer/contract.ts
+++ b/src/growth-forms-renderer/contract.ts
@@ -70,6 +70,10 @@ export interface RendererFieldDefinition {
   placeholder?: string
   required?: boolean
   options?: RendererFieldOption[]
+  /** Multiselect libre tipo chips/tags. El renderer conserva el valor como string[]. */
+  freeEntry?: boolean
+  /** Límite de items para multiselect/chips. */
+  maxItems?: number
   maxLength?: number
   /** Token WHATWG (`email`, `name`, `tel`, `organization`, …). Lo declara el contract. */
   autocomplete?: string

--- a/src/growth-forms-renderer/renderer.ts
+++ b/src/growth-forms-renderer/renderer.ts
@@ -449,6 +449,8 @@ export class FormRenderer {
       checkWrap.appendChild(control)
       checkWrap.appendChild(el(this.doc, 'span', {}, label))
       wrap.appendChild(checkWrap)
+    } else if (control.classList.contains('ghf-tag-input')) {
+      wrap.appendChild(control)
     } else if (field.type === 'select' || field.type === 'multiselect') {
       const controlWrap = el(this.doc, 'div', { class: 'ghf-control ghf-control--select' })
       const customSelect = control.classList.contains('ghf-select-composite')
@@ -547,6 +549,8 @@ export class FormRenderer {
         if (this.usesPremiumSelect()) return this.renderPremiumSelectControl(field, common)
 
       case 'multiselect': {
+        if (field.type === 'multiselect' && field.freeEntry) return this.renderTagMultiSelectControl(field, common)
+
         const select = el(this.doc, 'select', { ...common, class: 'ghf-select' })
 
         if (field.type === 'multiselect') select.setAttribute('multiple', 'multiple')
@@ -768,6 +772,123 @@ export class FormRenderer {
         if (!wrap.contains(this.doc.activeElement)) setOpen(false)
       }, 0)
     })
+
+    return wrap
+  }
+
+  private renderTagMultiSelectControl(field: RendererFieldDefinition, common: Record<string, string>): HTMLElement {
+    const maxItems = Math.max(1, Math.min(field.maxItems ?? 5, 50))
+    const wrap = el(this.doc, 'div', { class: 'ghf-tag-input', 'data-maxed': 'false' })
+    const list = el(this.doc, 'div', { class: 'ghf-tag-list', 'aria-live': 'polite' })
+
+    const input = el(this.doc, 'input', {
+      ...common,
+      type: 'text',
+      class: 'ghf-tag-entry',
+      autocomplete: 'off',
+      inputmode: 'text',
+    })
+
+    if (field.placeholder) input.setAttribute('placeholder', field.placeholder)
+    if (field.maxLength) input.setAttribute('maxlength', String(field.maxLength))
+
+    const currentValues = (): string[] => {
+      const value = this.values[field.key]
+
+      return Array.isArray(value) ? value : []
+    }
+
+    const setValues = (values: string[]) => {
+      this.values[field.key] = values
+      this.touched.add(field.key)
+      this.liveStatus(field)
+      this.onValueChange(field)
+    }
+
+    const renderTags = () => {
+      const values = currentValues()
+
+      list.replaceChildren()
+      wrap.dataset.maxed = values.length >= maxItems ? 'true' : 'false'
+      input.disabled = values.length >= maxItems
+      input.setAttribute('aria-disabled', input.disabled ? 'true' : 'false')
+      input.setAttribute('placeholder', values.length >= maxItems ? `Máximo ${maxItems}` : field.placeholder ?? '')
+
+      values.forEach((value, index) => {
+        const chip = el(this.doc, 'span', { class: 'ghf-tag-chip' })
+        const label = el(this.doc, 'span', { class: 'ghf-tag-label' }, value)
+
+        const remove = el(this.doc, 'button', {
+          type: 'button',
+          class: 'ghf-tag-remove',
+          'aria-label': `Quitar ${value}`,
+        }, '×')
+
+        remove.addEventListener('click', () => {
+          setValues(currentValues().filter((_, itemIndex) => itemIndex !== index))
+          renderTags()
+          input.focus()
+        })
+
+        chip.appendChild(label)
+        chip.appendChild(remove)
+        list.appendChild(chip)
+      })
+    }
+
+    const addTag = (raw: string): boolean => {
+      const next = raw.replace(/,$/, '').trim().replace(/\s+/g, ' ')
+
+      if (!next) return false
+
+      const values = currentValues()
+      const exists = values.some(value => value.toLocaleLowerCase('es-CL') === next.toLocaleLowerCase('es-CL'))
+
+      if (exists || values.length >= maxItems) return false
+
+      setValues([...values, next])
+      input.value = ''
+      renderTags()
+
+      return true
+    }
+
+    input.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ',') {
+        event.preventDefault()
+        addTag(input.value)
+      } else if (event.key === 'Backspace' && input.value === '') {
+        const values = currentValues()
+
+        if (values.length > 0) {
+          event.preventDefault()
+          setValues(values.slice(0, -1))
+          renderTags()
+        }
+      }
+    })
+
+    input.addEventListener('input', () => {
+      if (input.value.includes(',')) {
+        const parts = input.value.split(',')
+        const rest = parts.pop() ?? ''
+
+        parts.forEach(part => addTag(part))
+        input.value = rest
+      }
+
+      this.maybeStart()
+      this.onFieldEdited()
+    })
+
+    input.addEventListener('blur', () => {
+      addTag(input.value)
+      this.revalidateField(field)
+    })
+
+    wrap.appendChild(list)
+    wrap.appendChild(input)
+    renderTags()
 
     return wrap
   }

--- a/src/growth-forms-renderer/styles.ts
+++ b/src/growth-forms-renderer/styles.ts
@@ -188,20 +188,21 @@ export const RENDERER_CSS = `
   .ghf-textarea:focus-visible,
   .ghf-select:focus-visible,
   .ghf-tel-country:focus-visible,
-  .ghf-check input:focus-visible,
   .ghf-btn:focus-visible {
     outline: 2px solid var(--ghf-focus);
     outline-offset: 2px;
   }
   .ghf-input:focus-visible,
   .ghf-textarea:focus-visible,
-  .ghf-select:focus-visible {
+  .ghf-select:focus-visible,
+  .ghf-tag-input:focus-within {
     box-shadow: var(--ghf-field-shadow-focus);
   }
 
   .ghf-field[data-invalid="true"] .ghf-input,
   .ghf-field[data-invalid="true"] .ghf-textarea,
-  .ghf-field[data-invalid="true"] .ghf-select {
+  .ghf-field[data-invalid="true"] .ghf-select,
+  .ghf-field[data-invalid="true"] .ghf-tag-input {
     border-color: var(--ghf-error);
     background: var(--ghf-field-bg);
     box-shadow: 0 0 0 3px rgba(179, 35, 56, 0.10);
@@ -348,6 +349,87 @@ export const RENDERER_CSS = `
     color: var(--ghf-accent-contrast);
     font-weight: 700;
   }
+
+  .ghf-tag-input {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 44px;
+    width: 100%;
+    padding: 8px 10px;
+    color: var(--ghf-fg);
+    background: var(--ghf-field-bg);
+    border: 1px solid var(--ghf-border);
+    border-radius: var(--ghf-radius);
+    box-shadow: var(--ghf-field-shadow);
+    transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+  }
+  [data-ghf-style-variant="diagnostic_premium"] .ghf-tag-input {
+    min-height: 52px;
+    padding: 10px 12px;
+    border-radius: var(--ghf-radius);
+  }
+  .ghf-tag-input:hover { border-color: var(--ghf-border-strong); }
+  .ghf-tag-list { display: contents; }
+  .ghf-tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    min-height: 32px;
+    padding: 5px 6px 5px 11px;
+    border: 1px solid color-mix(in srgb, var(--ghf-accent) 36%, var(--ghf-border));
+    border-radius: 999px;
+    color: color-mix(in srgb, var(--ghf-fg) 86%, var(--ghf-accent));
+    background: color-mix(in srgb, var(--ghf-accent) 9%, var(--ghf-field-bg));
+    font-size: 0.875rem;
+    line-height: 1.2;
+  }
+  .ghf-tag-label {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+  .ghf-tag-remove {
+    display: inline-grid;
+    place-items: center;
+    inline-size: 24px;
+    block-size: 24px;
+    border: 0;
+    border-radius: 999px;
+    color: var(--ghf-muted);
+    background: transparent;
+    cursor: pointer;
+    font: inherit;
+    font-size: 1rem;
+    line-height: 1;
+    transition: color 140ms ease, background-color 140ms ease, transform 140ms ease;
+  }
+  .ghf-tag-remove:hover {
+    color: var(--ghf-fg);
+    background: color-mix(in srgb, var(--ghf-accent) 14%, transparent);
+  }
+  .ghf-tag-remove:focus-visible {
+    outline: 2px solid var(--ghf-focus);
+    outline-offset: 2px;
+  }
+  .ghf-tag-entry {
+    flex: 1 1 12rem;
+    min-width: min(100%, 12rem);
+    min-height: 32px;
+    padding: 4px 2px;
+    border: 0;
+    outline: 0;
+    color: var(--ghf-fg);
+    background: transparent;
+    font: inherit;
+    line-height: 1.4;
+  }
+  .ghf-tag-entry::placeholder {
+    color: color-mix(in srgb, var(--ghf-muted) 78%, transparent);
+  }
+  .ghf-tag-entry:disabled { cursor: not-allowed; }
+
   .ghf-field[data-status="success"] .ghf-status-icon { display: block; color: var(--ghf-success); }
   .ghf-field[data-status="success"] .ghf-status-icon::before { content: "✓"; font-weight: 700; }
   .ghf-field[data-status="success"] .ghf-input { border-color: var(--ghf-success); padding-right: 36px; }
@@ -428,13 +510,86 @@ export const RENDERER_CSS = `
   .ghf-tel-input { flex: 1 1 auto; min-width: 0; }
   .ghf-field[data-invalid="true"] .ghf-tel-country { border-color: var(--ghf-error); }
 
-  .ghf-check { display: flex; align-items: flex-start; gap: 10px; cursor: pointer; }
-  .ghf-check input { width: 24px; height: 24px; flex: 0 0 auto; accent-color: var(--ghf-accent); }
-  .ghf-check span { font-size: 0.875rem; line-height: 1.45; }
+  .ghf-check {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    min-height: 48px;
+    padding: 12px 14px;
+    border: 1px solid var(--ghf-border);
+    border-radius: var(--ghf-radius);
+    background: color-mix(in srgb, var(--ghf-field-bg) 94%, var(--ghf-accent));
+    cursor: pointer;
+    transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+  }
+  .ghf-check:hover {
+    border-color: var(--ghf-border-strong);
+    background: color-mix(in srgb, var(--ghf-field-bg) 90%, var(--ghf-accent));
+  }
+  .ghf-check input {
+    position: absolute;
+    inset-block-start: 12px;
+    inset-inline-start: 14px;
+    z-index: 1;
+    inline-size: 24px;
+    block-size: 24px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  .ghf-check span {
+    position: relative;
+    min-height: 24px;
+    padding-inline-start: 36px;
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    color: var(--ghf-fg);
+  }
+  .ghf-check span::before {
+    content: "";
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    inline-size: 24px;
+    block-size: 24px;
+    border: 1.5px solid var(--ghf-border-strong);
+    border-radius: 7px;
+    background: var(--ghf-field-bg);
+    box-shadow: var(--ghf-field-shadow);
+    transition: border-color 140ms ease, background-color 140ms ease, box-shadow 140ms ease;
+  }
+  .ghf-check span::after {
+    content: "";
+    position: absolute;
+    display: none;
+    inset-block-start: 4px;
+    inset-inline-start: 9px;
+    inline-size: 6px;
+    block-size: 12px;
+    border: solid var(--ghf-accent-contrast);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+  .ghf-check input:checked + span::before {
+    border-color: var(--ghf-accent);
+    background: var(--ghf-accent);
+    box-shadow: 0 8px 18px color-mix(in srgb, var(--ghf-accent) 28%, transparent);
+  }
+  .ghf-check input:checked + span::after { display: block; }
+  .ghf-check input:focus-visible + span::before {
+    outline: 2px solid var(--ghf-focus);
+    outline-offset: 3px;
+  }
   .ghf-check a { color: var(--ghf-accent); }
 
   .ghf-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
-  [data-ghf-style-variant="diagnostic_premium"] .ghf-actions { justify-content: center; }
+  [data-ghf-style-variant="diagnostic_premium"] .ghf-actions {
+    width: min(100%, 560px);
+    justify-content: center;
+    align-items: center;
+  }
   .ghf-btn {
     font: inherit; font-weight: 600;
     min-height: 44px; padding: 10px 20px;
@@ -450,13 +605,19 @@ export const RENDERER_CSS = `
     justify-content: center;
     gap: 10px;
     min-height: 52px;
-    min-width: min(100%, 420px);
+    min-width: 0;
     padding: 13px 26px;
     font-weight: 700;
     letter-spacing: 0 !important;
   }
-  [data-ghf-style-variant="diagnostic_premium"] .ghf-btn--ghost {
-    min-width: 0;
+  [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn:not(.ghf-btn--ghost) {
+    flex: 1 1 300px;
+    max-width: 380px;
+  }
+  [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn--ghost {
+    flex: 0 0 auto;
+    min-width: 112px;
+    box-shadow: 0 8px 18px rgba(16, 24, 39, 0.06);
   }
   .ghf-btn-arrow {
     display: inline-block;
@@ -472,6 +633,20 @@ export const RENDERER_CSS = `
   .ghf-btn--skip { color: var(--ghf-fg); opacity: 0.78; border-color: transparent; box-shadow: none; }
   .ghf-btn--skip:hover:not(:disabled) { opacity: 1; color: var(--ghf-fg); border-color: var(--ghf-border); box-shadow: none; filter: none; }
 
+  @container (max-width: 520px) {
+    [data-ghf-style-variant="diagnostic_premium"] .ghf-actions {
+      width: 100%;
+      align-items: stretch;
+    }
+    [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn,
+    [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn--ghost,
+    [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn:not(.ghf-btn--ghost) {
+      flex: 1 1 100%;
+      width: 100%;
+      max-width: none;
+    }
+  }
+
   /* TASK-1298 — hostile-host hardening.
      WordPress/Ohio can apply aggressive input/select/button declarations (including
      background images on selects and default dark button skins). These rules keep the
@@ -479,9 +654,11 @@ export const RENDERER_CSS = `
   greenhouse-form .ghf-form .ghf-input,
   greenhouse-form .ghf-form .ghf-textarea,
   greenhouse-form .ghf-form .ghf-select,
+  greenhouse-form .ghf-form .ghf-tag-input,
   .ghf-scope .ghf-form .ghf-input,
   .ghf-scope .ghf-form .ghf-textarea,
-  .ghf-scope .ghf-form .ghf-select {
+  .ghf-scope .ghf-form .ghf-select,
+  .ghf-scope .ghf-form .ghf-tag-input {
     font: inherit !important;
     color: var(--ghf-fg) !important;
     background: var(--ghf-field-bg) !important;
@@ -495,18 +672,22 @@ export const RENDERER_CSS = `
   greenhouse-form .ghf-form .ghf-input:focus-visible,
   greenhouse-form .ghf-form .ghf-textarea:focus-visible,
   greenhouse-form .ghf-form .ghf-select:focus-visible,
+  greenhouse-form .ghf-form .ghf-tag-input:focus-within,
   .ghf-scope .ghf-form .ghf-input:focus-visible,
   .ghf-scope .ghf-form .ghf-textarea:focus-visible,
-  .ghf-scope .ghf-form .ghf-select:focus-visible {
+  .ghf-scope .ghf-form .ghf-select:focus-visible,
+  .ghf-scope .ghf-form .ghf-tag-input:focus-within {
     box-shadow: var(--ghf-field-shadow-focus) !important;
   }
 
   greenhouse-form .ghf-form .ghf-field[data-invalid="true"] .ghf-input,
   greenhouse-form .ghf-form .ghf-field[data-invalid="true"] .ghf-textarea,
   greenhouse-form .ghf-form .ghf-field[data-invalid="true"] .ghf-select,
+  greenhouse-form .ghf-form .ghf-field[data-invalid="true"] .ghf-tag-input,
   .ghf-scope .ghf-form .ghf-field[data-invalid="true"] .ghf-input,
   .ghf-scope .ghf-form .ghf-field[data-invalid="true"] .ghf-textarea,
-  .ghf-scope .ghf-form .ghf-field[data-invalid="true"] .ghf-select {
+  .ghf-scope .ghf-form .ghf-field[data-invalid="true"] .ghf-select,
+  .ghf-scope .ghf-form .ghf-field[data-invalid="true"] .ghf-tag-input {
     border-color: var(--ghf-error) !important;
     background-color: var(--ghf-field-bg) !important;
     box-shadow: 0 0 0 3px rgba(179, 35, 56, 0.10) !important;
@@ -518,6 +699,18 @@ export const RENDERER_CSS = `
   .ghf-scope .ghf-form .ghf-tel-country {
     background-image: none !important;
     background-repeat: no-repeat !important;
+    text-transform: none !important;
+  }
+
+  greenhouse-form .ghf-form .ghf-tag-entry,
+  .ghf-scope .ghf-form .ghf-tag-entry {
+    font: inherit !important;
+    color: var(--ghf-fg) !important;
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    outline: 0 !important;
+    letter-spacing: normal !important;
     text-transform: none !important;
   }
 
@@ -1061,7 +1254,7 @@ export const RENDERER_CSS = `
   }
 
   @media (forced-colors: active) {
-    .ghf-input, .ghf-textarea, .ghf-select { border-color: ButtonText; }
+    .ghf-input, .ghf-textarea, .ghf-select, .ghf-tag-input, .ghf-check { border-color: ButtonText; }
     .ghf-btn { border-color: ButtonText; }
     .ghf-field[data-invalid="true"] .ghf-input { border-color: Mark; }
     .ghf-success-card,

--- a/src/growth-forms-renderer/validation.ts
+++ b/src/growth-forms-renderer/validation.ts
@@ -97,7 +97,9 @@ export const validateField = (
     return reasonToMessage(result.reasonCode, copy)
   }
 
-  if (field.maxLength && value.length > field.maxLength) {
+  if (field.maxLength && field.type === 'multiselect' && Array.isArray(raw)) {
+    if (raw.some(item => item.length > field.maxLength!)) return copy.errors.maxLength(field.maxLength)
+  } else if (field.maxLength && value.length > field.maxLength) {
     return copy.errors.maxLength(field.maxLength)
   }
 

--- a/src/lib/growth/forms/__tests__/revalidate.test.ts
+++ b/src/lib/growth/forms/__tests__/revalidate.test.ts
@@ -57,4 +57,29 @@ describe('revalidateAndNormalizeFields (autoridad server-side TASK-1253)', () =>
     expect(r.ok).toBe(true)
     if (r.ok) expect(r.normalizedFields.utm_source).toBe('newsletter')
   })
+
+  it('preserva multiselect como string[] normalizado, deduplicado y limitado', () => {
+    const r = revalidateAndNormalizeFields([
+      { key: 'competitorsDeclared', type: 'multiselect', freeEntry: true, maxItems: 3 },
+    ] as unknown as FieldDefinition[], {
+      competitorsDeclared: [' Marca A ', 'Marca B', 'marca a', 'Marca C', 'Marca D'],
+    })
+
+    expect(r.ok).toBe(true)
+
+    if (r.ok) {
+      expect(r.normalizedFields.competitorsDeclared).toEqual(['Marca A', 'Marca B', 'Marca C'])
+    }
+  })
+
+  it('acepta multiselect legacy separado por comas sin colapsarlo a texto', () => {
+    const r = revalidateAndNormalizeFields([
+      { key: 'competitorsDeclared', type: 'multiselect', freeEntry: true },
+    ] as unknown as FieldDefinition[], {
+      competitorsDeclared: 'Marca A, Marca B',
+    })
+
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.normalizedFields.competitorsDeclared).toEqual(['Marca A', 'Marca B'])
+  })
 })

--- a/src/lib/growth/forms/commands.ts
+++ b/src/lib/growth/forms/commands.ts
@@ -300,6 +300,35 @@ export const revalidateAndNormalizeFields = (
 
     if (raw == null || (typeof raw === 'string' && raw.trim() === '')) continue
 
+    if (field.type === 'multiselect') {
+      if (!Array.isArray(raw) && typeof raw !== 'string') {
+        return { ok: false, fieldKey: field.key, reasonCode: 'field_required' }
+      }
+
+      const source = Array.isArray(raw) ? raw : raw.split(',')
+      const values: string[] = []
+      const seen = new Set<string>()
+
+      for (const item of source) {
+        const value = String(item).trim()
+        const key = value.toLocaleLowerCase('es-CL')
+
+        if (!value || seen.has(key)) continue
+
+        if (field.maxLength && value.length > field.maxLength) {
+          return { ok: false, fieldKey: field.key, reasonCode: 'max_length' }
+        }
+
+        if (field.maxItems && values.length >= field.maxItems) break
+
+        seen.add(key)
+        values.push(value)
+      }
+
+      normalized[field.key] = values
+      continue
+    }
+
     const result = validateFieldValue(field, raw)
 
     if (!result.valid && result.reasonCode) {

--- a/src/lib/growth/forms/contracts.ts
+++ b/src/lib/growth/forms/contracts.ts
@@ -225,6 +225,8 @@ export const fieldDefinitionSchema = z.object({
   placeholder: z.string().max(200).optional(),
   required: z.boolean().default(false),
   options: z.array(z.object({ value: z.string(), label: z.string().optional(), copyRef: z.string().optional() })).optional(),
+  freeEntry: z.boolean().optional(),
+  maxItems: z.number().int().positive().max(50).optional(),
   maxLength: z.number().int().positive().max(10_000).optional(),
   autocomplete: z.string().max(40).optional(),
   inputMode: z.string().max(20).optional(),


### PR DESCRIPTION
TASK-1327 release patch.\n\nChanges:\n- Adds governed free-entry chip multiselect support for premium Growth Forms.\n- Keeps market/category/industry/persona/company size as governed select controls.\n- Improves consent checkbox styling and compact premium action layout.\n- Updates grader activation script runtime guard and contract copy.\n\nVerification:\n- pnpm vitest run src/growth-forms-renderer/__tests__/renderer.test.ts src/lib/growth/forms/__tests__/revalidate.test.ts src/lib/growth/forms/__tests__/renderer-contract-parity.test.ts\n- pnpm typecheck\n- pnpm renderer:build\n\nNote: activation dry-run requires ops Postgres env and will be run from the configured operational checkout after production code deploy.