### PR TITLE
fix(growth-forms): keep premium actions inline

### DIFF
--- a/src/growth-forms-renderer/styles.ts
+++ b/src/growth-forms-renderer/styles.ts
@@ -586,7 +586,7 @@ export const RENDERER_CSS = `
 
   .ghf-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
   [data-ghf-style-variant="diagnostic_premium"] .ghf-actions {
-    width: min(100%, 560px);
+    width: min(100%, 720px);
     justify-content: center;
     align-items: center;
   }
@@ -611,7 +611,7 @@ export const RENDERER_CSS = `
     letter-spacing: 0 !important;
   }
   [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn:not(.ghf-btn--ghost) {
-    flex: 1 1 300px;
+    flex: 1 1 260px;
     max-width: 380px;
   }
   [data-ghf-style-variant="diagnostic_premium"] .ghf-actions .ghf-btn--ghost {


### PR DESCRIPTION
Fast UI hotfix for TASK-1327.\n\nChange:\n- Widens the diagnostic premium action rail on desktop so Atrás, Continuar and Omitir contexto can sit in one row.\n- Keeps the existing container-query wrap for compact/mobile layouts.\n\nVerification:\n- pnpm renderer:build\n- pnpm vitest run src/growth-forms-renderer/__tests__/renderer.test.ts