### PR TITLE
fix(growth-forms): use supported Turnstile execution mode

### DIFF
--- a/src/growth-forms-renderer/__tests__/renderer.test.ts
+++ b/src/growth-forms-renderer/__tests__/renderer.test.ts
@@ -1110,6 +1110,8 @@ describe('growth-forms-renderer · FormRenderer', () => {
 
     expect(body.captchaToken).toBe('captcha-token')
     expect(turnstile.render).toHaveBeenCalledTimes(1)
+    expect(turnstile.render.mock.calls[0]?.[1]).toMatchObject({ appearance: 'interaction-only', execution: 'execute' })
+    expect(turnstile.render.mock.calls[0]?.[1]).not.toHaveProperty('size')
     expect(turnstile.execute).toHaveBeenCalledWith('widget-1')
     expect(turnstile.reset).toHaveBeenCalledWith('widget-1')
   })

--- a/src/growth-forms-renderer/turnstile.ts
+++ b/src/growth-forms-renderer/turnstile.ts
@@ -4,7 +4,7 @@ type TurnstileWidgetId = string | number
 
 interface TurnstileRenderOptions {
   sitekey: string
-  size: 'invisible'
+  appearance: 'interaction-only'
   execution: 'execute'
   callback: (token: string) => void
   'error-callback': () => void
@@ -138,7 +138,7 @@ export class TurnstileTokenClient {
     this.api = api
     this.widgetId = api.render(container, {
       sitekey: this.config.siteKey,
-      size: 'invisible',
+      appearance: 'interaction-only',
       execution: 'execute',
       callback: token => this.resolveToken(token),
       'error-callback': () => this.rejectToken(new Error('turnstile_token_failed')),


### PR DESCRIPTION
## Summary
- Replace unsupported Cloudflare Turnstile render option size=invisible with appearance=interaction-only plus execution=execute.
- Add renderer regression assertion so the Turnstile render options do not include size.

## Evidence
- pnpm vitest run src/growth-forms-renderer/__tests__/renderer.test.ts: 43 passed.
- pnpm typecheck: passed.
- pnpm build: passed, with existing Roadmap Turbopack broad-pattern warning.
- pre-push pnpm local:check: passed.

Root cause confirmed in production browser diagnostics: Cloudflare Turnstile raised Invalid value for parameter size, expected compact/flexible/normal, got invisible, so the renderer never acquired captchaToken before submit.