### PR TITLE
fix(release): authenticate AXIS packages in Cloud Build workers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,6 +47,7 @@ node_modules/
 .env*
 !.env.example
 !.env.local.example
+.npmrc
 
 # Repo areas not needed by current Cloud Run worker images
 bigquery/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -47,6 +47,7 @@ node_modules/
 .env*
 !.env.example
 !.env.local.example
+.npmrc
 
 # Repo areas not needed by current Cloud Run worker images
 artifacts/

--- a/Handoff.md
+++ b/Handoff.md
@@ -29,6 +29,11 @@ La revisión de arquitectura añadió `.npmrc` a `.dockerignore` y `.gcloudignor
 explícitos y el archivo no entraba a las imágenes, el secreto efímero tampoco debe viajar dentro del contexto enviado
 al daemon de Docker. El worker build-contract gate ahora bloquea ambas omisiones.
 
+El inventario completo de build units detectó un cuarto consumidor: `artifact-worker` instala el mismo `package.json`
+y por tanto también requiere AXIS auth, aunque sea un Cloud Run Job staging-only y no forme parte del orchestrator
+productivo. Su Dockerfile/deploy script ahora usan el mismo contrato `secretEnv` → `.npmrc` efímero → BuildKit secret;
+el gate exige el montaje en los cuatro Dockerfiles.
+
 La ubicación en `efeonce-globe` es un acoplamiento legado deliberado y temporal, no ownership de Globe. La decisión de
 retiro está atada a ownership: cuando se cree la identidad de máquina, el secreto nuevo debe nacer en un proyecto
 neutral del ecosistema AXIS, fuera de cualquier producto; después se migran ambos consumers, se completan build/digest

--- a/Handoff.md
+++ b/Handoff.md
@@ -1,6 +1,6 @@
 # Handoff activo
 
-## 2026-07-29 — Production release: Cloud Build AXIS auth blocker identified and fixed in develop
+## 2026-07-29 — Production release: Cloud Build AXIS auth wiring fixed; credential expired
 
 `main` sigue en `9bb780ba4c41bfdf40903b762194fb6bb8085b59`, con CI, CI Deep, smoke, Vercel Production READY,
 preflight y manifest verdes. El orchestrator `30465872005` llegó al gate Production, fue aprobado por la sesión
@@ -12,12 +12,16 @@ La evidencia de Cloud Build (`322e8c71`, `f7da8e53`, `cd604434`) fue `ERR_PNPM_F
 `@efeoncepro/axis-tokens`: `No authorization header was set`. La causa era que los tres Dockerfiles y sus inline
 Cloud Build configs instalaban paquetes privados sin el secreto AXIS.
 
-Fix code-complete en develop, pendiente de PR/gates y nuevo release: los tres deploy scripts leen
+Fix code-complete en develop, con PR #166 pendiente de gates y nuevo release: los tres deploy scripts leen
 `projects/efeonce-globe/secrets/axis-packages-read-token` con `secretEnv`, materializan `.npmrc` efímero con
 `trap`, ejecutan Docker BuildKit `--secret`, y los tres Dockerfiles montan `axis_npmrc` en builder y runtime.
 Se concedió `secretAccessor` únicamente a `183008134038-compute@developer.gserviceaccount.com`. No se expuso token en
 logs, imagen, artefactos ni runtime. Gates locales `worker-build-contract`, `worker-runtime-deps` y 10 tests focales
-pasaron. Falta push/PR, CI, reintentar el orchestrator y verificar los tres digests/health checks.
+pasaron. El carril real de Cloud Build ya montó el `.npmrc`, pero GitHub Packages respondió `401 Unauthorized` en
+los tres builds nuevos (`d393c460`, `367ee552`, `f356a7bd`); el secreto tiene una única versión creada el
+2026-07-28 y su PAT está vencido o revocado. Por tanto falta renovar el PAT read-only fuera del repositorio,
+crear una nueva versión del secreto y revalidar CI, Vercel y los tres digests/health checks. No se debe subir la
+credencial local del operador ni imprimirla.
 
 La ubicación en `efeonce-globe` es un acoplamiento legado deliberado y temporal, no ownership de Globe. La decisión de
 retiro está atada a ownership: cuando se cree la identidad de máquina, el secreto nuevo debe nacer en un proyecto

--- a/Handoff.md
+++ b/Handoff.md
@@ -1,6 +1,6 @@
 # Handoff activo
 
-## 2026-07-29 — Production release: Cloud Build AXIS auth wiring fixed; credential expired
+## 2026-07-29 — Production release: Cloud Build AXIS auth root cause isolated
 
 `main` sigue en `9bb780ba4c41bfdf40903b762194fb6bb8085b59`, con CI, CI Deep, smoke, Vercel Production READY,
 preflight y manifest verdes. El orchestrator `30465872005` llegó al gate Production, fue aprobado por la sesión
@@ -17,11 +17,13 @@ Fix code-complete en develop, con PR #166 pendiente de gates y nuevo release: lo
 `trap`, ejecutan Docker BuildKit `--secret`, y los tres Dockerfiles montan `axis_npmrc` en builder y runtime.
 Se concedió `secretAccessor` únicamente a `183008134038-compute@developer.gserviceaccount.com`. No se expuso token en
 logs, imagen, artefactos ni runtime. Gates locales `worker-build-contract`, `worker-runtime-deps` y 10 tests focales
-pasaron. El carril real de Cloud Build ya montó el `.npmrc`, pero GitHub Packages respondió `401 Unauthorized` en
-los tres builds nuevos (`d393c460`, `367ee552`, `f356a7bd`); el secreto tiene una única versión creada el
-2026-07-28 y su PAT está vencido o revocado. Por tanto falta renovar el PAT read-only fuera del repositorio,
-crear una nueva versión del secreto y revalidar CI, Vercel y los tres digests/health checks. No se debe subir la
-credencial local del operador ni imprimirla.
+pasaron. El carril real de Cloud Build montó el `.npmrc`, pero GitHub Packages respondió `401 Unauthorized` en los
+tres builds nuevos (`d393c460`, `367ee552`, `f356a7bd`). La verificación segura posterior demostró que el PAT no
+está vencido: el payload es un PAT clásico limpio, GitHub `/user` responde `200` y el tarball privado exacto responde
+`200`. La causa real era doble expansión de `$$` en el heredoc no quoted: el shell generador lo convertía en su PID
+antes de entregar el config a Cloud Build, lo que explica que cada build reportara un bearer numérico distinto.
+El fix preserva `$$AXIS_PACKAGES_READ_TOKEN` para que Cloud Build inyecte el secreto real. Falta revalidar CI, los
+tres builds/digests y repetir el orchestrator.
 
 La ubicación en `efeonce-globe` es un acoplamiento legado deliberado y temporal, no ownership de Globe. La decisión de
 retiro está atada a ownership: cuando se cree la identidad de máquina, el secreto nuevo debe nacer en un proyecto

--- a/Handoff.md
+++ b/Handoff.md
@@ -1,5 +1,24 @@
 # Handoff activo
 
+## 2026-07-29 — Production release: Cloud Build AXIS auth blocker identified and fixed in develop
+
+`main` sigue en `9bb780ba4c41bfdf40903b762194fb6bb8085b59`, con CI, CI Deep, smoke, Vercel Production READY,
+preflight y manifest verdes. El orchestrator `30465872005` llegó al gate Production, fue aprobado por la sesión
+autorizada y desplegó HubSpot correctamente, pero los builds Cloud Run de `ops-worker`, `commercial-cost-worker` e
+`ico-batch-worker` fallaron antes del deploy. Azure quedó en sus lanes normales de `no_infra_diff`/espera y no es la
+causa.
+
+La evidencia de Cloud Build (`322e8c71`, `f7da8e53`, `cd604434`) fue `ERR_PNPM_FETCH_401` para
+`@efeoncepro/axis-tokens`: `No authorization header was set`. La causa era que los tres Dockerfiles y sus inline
+Cloud Build configs instalaban paquetes privados sin el secreto AXIS.
+
+Fix code-complete en develop, pendiente de PR/gates y nuevo release: los tres deploy scripts leen
+`projects/efeonce-globe/secrets/axis-packages-read-token` con `secretEnv`, materializan `.npmrc` efímero con
+`trap`, ejecutan Docker BuildKit `--secret`, y los tres Dockerfiles montan `axis_npmrc` en builder y runtime.
+Se concedió `secretAccessor` únicamente a `183008134038-compute@developer.gserviceaccount.com`. No se expuso token en
+logs, imagen, artefactos ni runtime. Gates locales `worker-build-contract`, `worker-runtime-deps` y 10 tests focales
+pasaron. Falta push/PR, CI, reintentar el orchestrator y verificar los tres digests/health checks.
+
 ## 2026-07-29 — PR #164: main promovido, release bloqueado por latencia Sentry (fix en develop)
 
 `develop` quedó en `2ecef6a5c4c8a79a738536fe04192b7343e358b0` y PR #164 promovió todo el contenido a `main` mediante

--- a/Handoff.md
+++ b/Handoff.md
@@ -19,6 +19,11 @@ Se concedió `secretAccessor` únicamente a `183008134038-compute@developer.gser
 logs, imagen, artefactos ni runtime. Gates locales `worker-build-contract`, `worker-runtime-deps` y 10 tests focales
 pasaron. Falta push/PR, CI, reintentar el orchestrator y verificar los tres digests/health checks.
 
+La ubicación en `efeonce-globe` es un acoplamiento legado deliberado y temporal, no ownership de Globe. La decisión de
+retiro está atada a ownership: cuando se cree la identidad de máquina, el secreto nuevo debe nacer en un proyecto
+neutral del ecosistema AXIS, fuera de cualquier producto; después se migran ambos consumers, se completan build/digest
+gates y se revoca el binding cross-project. No se debe recrear el secreto nuevo en `efeonce-globe` por inercia.
+
 ## 2026-07-29 — PR #164: main promovido, release bloqueado por latencia Sentry (fix en develop)
 
 `develop` quedó en `2ecef6a5c4c8a79a738536fe04192b7343e358b0` y PR #164 promovió todo el contenido a `main` mediante

--- a/Handoff.md
+++ b/Handoff.md
@@ -25,6 +25,10 @@ antes de entregar el config a Cloud Build, lo que explica que cada build reporta
 El fix preserva `$$AXIS_PACKAGES_READ_TOKEN` para que Cloud Build inyecte el secreto real. Falta revalidar CI, los
 tres builds/digests y repetir el orchestrator.
 
+La revisión de arquitectura añadió `.npmrc` a `.dockerignore` y `.gcloudignore`: aunque los Dockerfiles usan `COPY`
+explícitos y el archivo no entraba a las imágenes, el secreto efímero tampoco debe viajar dentro del contexto enviado
+al daemon de Docker. El worker build-contract gate ahora bloquea ambas omisiones.
+
 La ubicación en `efeonce-globe` es un acoplamiento legado deliberado y temporal, no ownership de Globe. La decisión de
 retiro está atada a ownership: cuando se cree la identidad de máquina, el secreto nuevo debe nacer en un proyecto
 neutral del ecosistema AXIS, fuera de cualquier producto; después se migran ambos consumers, se completan build/digest

--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,23 @@
 # changelog.md
 
-## 2026-07-29 — Release Cloud Build: autenticación privada AXIS en workers
-
-- El release orchestrator `30465872005` reveló `ERR_PNPM_FETCH_401` en los builds Cloud Run de `ops-worker`,
-  `commercial-cost-worker` e `ico-batch-worker`: faltaba autorización para `@efeoncepro/axis-tokens`.
-- Los tres deploy scripts ahora usan el secreto read-only existente `axis-packages-read-token` mediante `secretEnv` y
-  `.npmrc` efímero; los Dockerfiles montan BuildKit secret en ambas capas `pnpm install`, sin token en imagen o runtime.
-- Se concedió acceso Secret Manager sólo al service account de Cloud Build de Greenhouse. Validaciones locales de
-  contratos de workers y tests focales pasaron; rollout queda pendiente de PR y nuevo orchestrator.
-
 > Ventana reciente de cambios internos reales. El historial completo y verificable se consulta en
 > [docs/changelog/internal/README.md](docs/changelog/internal/README.md). No cargar snapshots completos al
 > inicio ni usar una entrada histórica como contrato vigente sin contrastarla.
 >
 > Techo operativo: 60 entradas, 2.000 líneas y ~60.000 tokens. Rotación:
 > `pnpm docs:context-rotate --apply`.
+
+## 2026-07-29 — Release Cloud Build: autenticación privada AXIS en workers
+
+- El release orchestrator `30465872005` reveló `ERR_PNPM_FETCH_401` en los builds Cloud Run de `ops-worker`,
+  `commercial-cost-worker` e `ico-batch-worker`: faltaba autorización para `@efeoncepro/axis-tokens`.
+- Los tres deploy scripts ahora usan el secreto read-only existente `axis-packages-read-token` mediante `secretEnv` y
+  `.npmrc` efímero; los Dockerfiles montan BuildKit secret en ambas capas `pnpm install`, sin token en imagen o runtime.
+- La primera corrida autenticada aún respondió `401`: el PAT estaba sano, pero el heredoc no quoted expandía `$$` al
+  PID del shell antes de que Cloud Build pudiera resolver `secretEnv`. Los scripts ahora preservan el doble dólar
+  requerido por Cloud Build y un test de contrato cubre los tres consumidores.
+- Se concedió acceso Secret Manager sólo al service account de Cloud Build de Greenhouse. Validaciones locales de
+  contratos de workers y tests focales pasaron; rollout queda pendiente de PR y nuevo orchestrator.
 
 ## 2026-07-29 — Globe: contrato tipográfico del payload cliente + jerarquía del Producer (TASK-1599)
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@
 - La primera corrida autenticada aún respondió `401`: el PAT estaba sano, pero el heredoc no quoted expandía `$$` al
   PID del shell antes de que Cloud Build pudiera resolver `secretEnv`. Los scripts ahora preservan el doble dólar
   requerido por Cloud Build y un test de contrato cubre los tres consumidores.
+- `.dockerignore` y `.gcloudignore` excluyen `.npmrc`; el gate de contratos impide que el secreto efímero viaje en el
+  contexto de Docker o en un upload local accidental.
 - Se concedió acceso Secret Manager sólo al service account de Cloud Build de Greenhouse. Validaciones locales de
   contratos de workers y tests focales pasaron; rollout queda pendiente de PR y nuevo orchestrator.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # changelog.md
 
+## 2026-07-29 — Release Cloud Build: autenticación privada AXIS en workers
+
+- El release orchestrator `30465872005` reveló `ERR_PNPM_FETCH_401` en los builds Cloud Run de `ops-worker`,
+  `commercial-cost-worker` e `ico-batch-worker`: faltaba autorización para `@efeoncepro/axis-tokens`.
+- Los tres deploy scripts ahora usan el secreto read-only existente `axis-packages-read-token` mediante `secretEnv` y
+  `.npmrc` efímero; los Dockerfiles montan BuildKit secret en ambas capas `pnpm install`, sin token en imagen o runtime.
+- Se concedió acceso Secret Manager sólo al service account de Cloud Build de Greenhouse. Validaciones locales de
+  contratos de workers y tests focales pasaron; rollout queda pendiente de PR y nuevo orchestrator.
+
 > Ventana reciente de cambios internos reales. El historial completo y verificable se consulta en
 > [docs/changelog/internal/README.md](docs/changelog/internal/README.md). No cargar snapshots completos al
 > inicio ni usar una entrada histórica como contrato vigente sin contrastarla.
@@ -683,61 +692,3 @@ fuente de verdad. Nada autenticado se cachea, verificado path por path.
   `TASK-1561` cerró el gate de diseño (tipografía + frontera declarada). El selector de modelo del Producer
   (`TASK-1555`) quedó como desplegable compacto con isotipo real: la galería se implementó y el operador la
   rechazó al verla. Nuevas: `TASK-1559`, `TASK-1560`, `TASK-1562`.
-
-## 2026-07-25 — TASK-1558: el share board de Globe, la cara del cliente, reconstruida (ADR-014 Slice 1)
-
-- **La única superficie que un cliente externo ve de Globe deja de ser 15 líneas con 3.071 caracteres de CSS
-  en una sola línea.** Reconstruida como componentes tipados sobre el SSOT de tokens del payload cliente
-  (`efeonce-globe` `a336ff5`). Nacen las primeras primitives de Globe —`Chip`, `Eyebrow`, `FactList`,
-  `CommentList`, `MediaStage`, `StateBlock`— sirviendo a esta superficie; su promoción a plataforma se
-  **propone**, no se asume. `Surface` NO se entregó: la dirección elegida no la necesita y una primitive con
-  un solo consumer y ningún rol visual es una hipótesis.
-- **Dirección visual aprobada: B "lámina montada"** (passepartout + riel de líneas). Tres direcciones
-  renderizadas con los tokens y las fuentes reales y miradas en los dos targets, no comparadas en prosa.
-  **A se rechazó por descalificante**: `object-fit: cover` recorta la pieza y la viñeta le altera el color, o
-  sea corrompe el artefacto que el cliente vino a juzgar. **C** degradaba la pieza a ilustración de documento
-  y su fila de chips prometía filtros en una superficie read-only.
-- **Cuatro defectos verificados en la línea base, arreglados:** cards anidadas en el panel (card-on-card, que
-  el estándar de entrega trata como fallo de diseño); valores crudos al cliente (`changes_requested` y
-  `2026-08-01T18:00:00.000Z` iban directo a `textContent`); el rótulo interno `Producer`; y la ausencia total
-  de footer. La línea base "antes" se capturó antes de tocar nada — no existía.
-- **El estado que no existía y es el que ADR-005 pide de verdad: `partial`.** Si fallan los bytes, el
-  `.catch(fail)` de hoy tira **también** los hechos y los comentarios ya recibidos y pinta un mensaje
-  genérico — que es exactamente el "preview roto genérico" que la Delta prohíbe. Ahora el riel sobrevive
-  legible y sólo el stage degrada, con un Reintentar acotado a los bytes.
-- **Recalibración de la spec: los cuatro códigos de error NO son distinguibles, y es correcto.**
-  `publicShareError` (`app.ts:4143`) colapsa inválido/vencido/revocado/de-otro-target/denegado en **un 404 no
-  enumerable a propósito**, y sólo deja el 503 aparte para que el cliente pueda reintentar. Enumerarlos en la
-  UI reconstruiría el oráculo de grants que el colapso existe para evitar; además el `Out of Scope` de la
-  task prohíbe tocar el BFF. La regla de ADR-005 que se citaba gobierna el **feed del Producer**
-  (autenticado), no el share público. La unión discriminada real tiene 5 miembros.
-- **Tipografía al SSOT, con escala.** `--font-display`/`--font-body`, cuatro pasos sin huérfanos, leading,
-  pesos limitados a los tres cuts cargados, tracking y measure. La base sube a **16px**: el producer pone el
-  texto de lectura en ~13.6px, bajo el piso de 14px supplementary, y eso es defendible en una consola interna
-  donde el operador vive todo el día — no en la superficie que un cliente lee una vez, en un dispositivo
-  desconocido, para juzgar trabajo creativo. El riel se ensanchó a 22-27rem porque 52ch a 16px lo exige: a
-  24rem daban ~40 caracteres por línea, bajo el piso de 45.
-- **El gate de diseño pasa de 6 a 8 reglas y ahora camina `.css`.** Era el único lugar donde un hex, una
-  duración o una fuente podían seguir tipeándose a mano — un gate que deja de aplicar en cuanto el payload
-  gana su primer `.css` no es un gate. Reglas nuevas: tipografía literal, y **peso sin `@font-face`** (faux
-  bold renderiza, shippea y pasa todos los demás gates). Las cuatro verificadas rompiéndolas a propósito.
-  Y una lección de método: la primera versión de la regla de tipografía usaba un lookahead negativo cuyo
-  `\s*` retrocedía a ancho cero, así que **reportaba toda línea correctamente tokenizada**; una regla que
-  enrojece código compliant se apaga sola.
-- **`/legal/terms` retirado — y no estaba donde la spec decía.** El link roto que devolvía JSON crudo a un
-  browser vivía en el footer del **Producer** (`producer-ui.ts:82`), no en el share board, que no tiene ni
-  footer ni un solo `<a>`. Se retiró (ADR-014 lo prohíbe explícitamente) y el test que **fijaba su presencia**
-  quedó invertido, no borrado: un assert sobre la presencia de algo perpetúa el defecto cuando nadie pregunta
-  si debería estar.
-- **Primer canary visual de la superficie: 6 estados × 3 anchos** (1440, 390 y **320**, el piso de WCAG
-  1.4.10), con assertions de no-fuga sobre el HTML servido, overflow medido **por panel** y no sólo en el
-  documento, y Reintentar/`role=alert` verificados por estado. Encontró dos bugs reales antes del commit: el
-  chip "Sólo lectura" decidía el ancho de la página a 320px, y el bloque de estado de `partial` quedaba pegado
-  arriba en vez de centrado. Scorecard 4,71 promedio, piso 4.
-- **Estado honesto: code complete, rollout pendiente.** `client_app_enabled` sigue en `false` y el payload
-  viejo responde idéntico — **con test**, no como afirmación. Faltan el `terraform apply` del flip y el retiro
-  de `public-share-ui.ts`, que va después del flip verificado con un grant real.
-- **Brechas declaradas, no silenciadas:** no hay captions de video/audio porque `CreativeShareBoardV1` no
-  transporta pista (WCAG 1.2.2; `eslint-disable` justificado, cerrarlo es cambio de contrato); el `h1` usa un
-  fallback para toda pieza y los comentarios van sin autor porque la proyección no tiene esos campos, y
-  inventarlos en la superficie donde un cliente juzga trabajo sería fabricar evidencia.

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@
   requerido por Cloud Build y un test de contrato cubre los tres consumidores.
 - `.dockerignore` y `.gcloudignore` excluyen `.npmrc`; el gate de contratos impide que el secreto efímero viaje en el
   contexto de Docker o en un upload local accidental.
+- `artifact-worker`, cuarto build unit que instala el `package.json` raíz, adoptó el mismo montaje BuildKit; el gate
+  ahora exige AXIS auth en todas las etapas `pnpm install` de los cuatro workers.
 - Se concedió acceso Secret Manager sólo al service account de Cloud Build de Greenhouse. Validaciones locales de
   contratos de workers y tests focales pasaron; rollout queda pendiente de PR y nuevo orchestrator.
 

--- a/docs/architecture/EFEONCE_SHARED_PRODUCT_UI_PLATFORM_DECISION_V1.md
+++ b/docs/architecture/EFEONCE_SHARED_PRODUCT_UI_PLATFORM_DECISION_V1.md
@@ -73,8 +73,11 @@ persistencia o jobs.
   Greenhouse `183008134038-compute@developer.gserviceaccount.com` tienen
   `roles/secretmanager.secretAccessor` sobre ese secreto. La ubicación es ownership
   deliberado del ecosistema AXIS, no una credencial exclusiva de Globe; no se duplica
-  el PAT. Este binding cross-project se retira al migrar ambos consumers a una identidad
-  de máquina dedicada y rotar el secreto, con sus gates de build/digest completos.
+  el PAT. La retirada es una decisión de ownership, no un vencimiento: al crear la
+  identidad de máquina, el secreto nuevo debe nacer en un proyecto neutral del
+  ecosistema AXIS, fuera de cualquier producto. Sólo después de migrar ambos consumers
+  y completar sus gates de build/digest se revoca el binding cross-project y se retira
+  el secreto legado; nunca se recrea en `efeonce-globe` por inercia.
 - Greenhouse y Globe consumen `efeonce.status` y `efeonce.progress` en adapters opt-in de
   `TASK-1591`, cada uno con una primitive simple y una compleja nativa a su runtime.
 - El token de GitHub usado para esta preparación es operator-owned y tiene expiración

--- a/docs/architecture/EFEONCE_SHARED_PRODUCT_UI_PLATFORM_DECISION_V1.md
+++ b/docs/architecture/EFEONCE_SHARED_PRODUCT_UI_PLATFORM_DECISION_V1.md
@@ -69,8 +69,12 @@ persistencia o jobs.
   lockfile en los consumers.
 - En GCP, proyecto `efeonce-globe`, existe el secreto de Secret Manager
   `axis-packages-read-token`. El service account de Cloud Build
-  `818083690953-compute@developer.gserviceaccount.com` tiene
-  `roles/secretmanager.secretAccessor` sobre ese secreto.
+  `818083690953-compute@developer.gserviceaccount.com` y el de Cloud Build de
+  Greenhouse `183008134038-compute@developer.gserviceaccount.com` tienen
+  `roles/secretmanager.secretAccessor` sobre ese secreto. La ubicación es ownership
+  deliberado del ecosistema AXIS, no una credencial exclusiva de Globe; no se duplica
+  el PAT. Este binding cross-project se retira al migrar ambos consumers a una identidad
+  de máquina dedicada y rotar el secreto, con sus gates de build/digest completos.
 - Greenhouse y Globe consumen `efeonce.status` y `efeonce.progress` en adapters opt-in de
   `TASK-1591`, cada uno con una primitive simple y una compleja nativa a su runtime.
 - El token de GitHub usado para esta preparación es operator-owned y tiene expiración

--- a/docs/changelog/internal/2026-07.md
+++ b/docs/changelog/internal/2026-07.md
@@ -2,6 +2,66 @@
 
 > Archivo histórico. Buscar por keyword; validar vigencia contra fuentes canónicas y runtime.
 
+<!-- changelog-entry-sha256:7aa622b092873560df81b0cad2e6c0e1ff2a1cceebdf9b2b8f6585a26cdf5249 -->
+
+## 2026-07-25 — TASK-1558: el share board de Globe, la cara del cliente, reconstruida (ADR-014 Slice 1)
+
+- **La única superficie que un cliente externo ve de Globe deja de ser 15 líneas con 3.071 caracteres de CSS
+  en una sola línea.** Reconstruida como componentes tipados sobre el SSOT de tokens del payload cliente
+  (`efeonce-globe` `a336ff5`). Nacen las primeras primitives de Globe —`Chip`, `Eyebrow`, `FactList`,
+  `CommentList`, `MediaStage`, `StateBlock`— sirviendo a esta superficie; su promoción a plataforma se
+  **propone**, no se asume. `Surface` NO se entregó: la dirección elegida no la necesita y una primitive con
+  un solo consumer y ningún rol visual es una hipótesis.
+- **Dirección visual aprobada: B "lámina montada"** (passepartout + riel de líneas). Tres direcciones
+  renderizadas con los tokens y las fuentes reales y miradas en los dos targets, no comparadas en prosa.
+  **A se rechazó por descalificante**: `object-fit: cover` recorta la pieza y la viñeta le altera el color, o
+  sea corrompe el artefacto que el cliente vino a juzgar. **C** degradaba la pieza a ilustración de documento
+  y su fila de chips prometía filtros en una superficie read-only.
+- **Cuatro defectos verificados en la línea base, arreglados:** cards anidadas en el panel (card-on-card, que
+  el estándar de entrega trata como fallo de diseño); valores crudos al cliente (`changes_requested` y
+  `2026-08-01T18:00:00.000Z` iban directo a `textContent`); el rótulo interno `Producer`; y la ausencia total
+  de footer. La línea base "antes" se capturó antes de tocar nada — no existía.
+- **El estado que no existía y es el que ADR-005 pide de verdad: `partial`.** Si fallan los bytes, el
+  `.catch(fail)` de hoy tira **también** los hechos y los comentarios ya recibidos y pinta un mensaje
+  genérico — que es exactamente el "preview roto genérico" que la Delta prohíbe. Ahora el riel sobrevive
+  legible y sólo el stage degrada, con un Reintentar acotado a los bytes.
+- **Recalibración de la spec: los cuatro códigos de error NO son distinguibles, y es correcto.**
+  `publicShareError` (`app.ts:4143`) colapsa inválido/vencido/revocado/de-otro-target/denegado en **un 404 no
+  enumerable a propósito**, y sólo deja el 503 aparte para que el cliente pueda reintentar. Enumerarlos en la
+  UI reconstruiría el oráculo de grants que el colapso existe para evitar; además el `Out of Scope` de la
+  task prohíbe tocar el BFF. La regla de ADR-005 que se citaba gobierna el **feed del Producer**
+  (autenticado), no el share público. La unión discriminada real tiene 5 miembros.
+- **Tipografía al SSOT, con escala.** `--font-display`/`--font-body`, cuatro pasos sin huérfanos, leading,
+  pesos limitados a los tres cuts cargados, tracking y measure. La base sube a **16px**: el producer pone el
+  texto de lectura en ~13.6px, bajo el piso de 14px supplementary, y eso es defendible en una consola interna
+  donde el operador vive todo el día — no en la superficie que un cliente lee una vez, en un dispositivo
+  desconocido, para juzgar trabajo creativo. El riel se ensanchó a 22-27rem porque 52ch a 16px lo exige: a
+  24rem daban ~40 caracteres por línea, bajo el piso de 45.
+- **El gate de diseño pasa de 6 a 8 reglas y ahora camina `.css`.** Era el único lugar donde un hex, una
+  duración o una fuente podían seguir tipeándose a mano — un gate que deja de aplicar en cuanto el payload
+  gana su primer `.css` no es un gate. Reglas nuevas: tipografía literal, y **peso sin `@font-face`** (faux
+  bold renderiza, shippea y pasa todos los demás gates). Las cuatro verificadas rompiéndolas a propósito.
+  Y una lección de método: la primera versión de la regla de tipografía usaba un lookahead negativo cuyo
+  `\s*` retrocedía a ancho cero, así que **reportaba toda línea correctamente tokenizada**; una regla que
+  enrojece código compliant se apaga sola.
+- **`/legal/terms` retirado — y no estaba donde la spec decía.** El link roto que devolvía JSON crudo a un
+  browser vivía en el footer del **Producer** (`producer-ui.ts:82`), no en el share board, que no tiene ni
+  footer ni un solo `<a>`. Se retiró (ADR-014 lo prohíbe explícitamente) y el test que **fijaba su presencia**
+  quedó invertido, no borrado: un assert sobre la presencia de algo perpetúa el defecto cuando nadie pregunta
+  si debería estar.
+- **Primer canary visual de la superficie: 6 estados × 3 anchos** (1440, 390 y **320**, el piso de WCAG
+  1.4.10), con assertions de no-fuga sobre el HTML servido, overflow medido **por panel** y no sólo en el
+  documento, y Reintentar/`role=alert` verificados por estado. Encontró dos bugs reales antes del commit: el
+  chip "Sólo lectura" decidía el ancho de la página a 320px, y el bloque de estado de `partial` quedaba pegado
+  arriba en vez de centrado. Scorecard 4,71 promedio, piso 4.
+- **Estado honesto: code complete, rollout pendiente.** `client_app_enabled` sigue en `false` y el payload
+  viejo responde idéntico — **con test**, no como afirmación. Faltan el `terraform apply` del flip y el retiro
+  de `public-share-ui.ts`, que va después del flip verificado con un grant real.
+- **Brechas declaradas, no silenciadas:** no hay captions de video/audio porque `CreativeShareBoardV1` no
+  transporta pista (WCAG 1.2.2; `eslint-disable` justificado, cerrarlo es cambio de contrato); el `h1` usa un
+  fallback para toda pieza y los comentarios van sin autor porque la proyección no tiene esos campos, y
+  inventarlos en la superficie donde un cliente juzga trabajo sería fabricar evidencia.
+
 <!-- changelog-entry-sha256:c34189d6d30c41a1365327a64d868959ee727596d701af2b8d2fe6880f1817e5 -->
 
 ## 2026-07-24 — ANAM publica ajustes del agente, backlog comercial y metas nativas

--- a/docs/operations/AXIS_CONTINUITY_MAP_2026-07-29.md
+++ b/docs/operations/AXIS_CONTINUITY_MAP_2026-07-29.md
@@ -84,6 +84,50 @@ Dockerfile (`68a2cbe`, `d009871`, `b9112a8`, `403d346`; revisión viva `00101-x2
 
 ---
 
+## 2-bis. Hueco que este mapa NO cubrió, y que apareció después (2026-07-29, `e3f3e667a`)
+
+**Los tres Cloud Run workers de Greenhouse construían con `401 Unauthorized` sobre `@efeoncepro/axis-tokens`.**
+
+Este diagnóstico verificó, para Greenhouse, **GitHub Actions** (10 workflows con wiring) y **Vercel**
+(`NPM_RC` en tres entornos) — y **no verificó su Cloud Build**. Greenhouse tiene un tercer carril de build que
+no es ninguno de esos dos: `services/{ops-worker,ico-batch,commercial-cost-worker}`, cada uno con su
+`Dockerfile` + `deploy.sh`. Ahí faltaba la auth.
+
+> **La lección de método, que vale más que el arreglo:** "el consumidor tiene la auth" no es una respuesta
+> hasta que se enumeran **todos** sus carriles de build. Greenhouse tiene tres (Actions, Vercel, Cloud Build);
+> comprobar dos y concluir da un verde que no existe.
+
+Corregido aplicando el patrón canónico de Globe —Secret Manager + BuildKit `--mount=type=secret`, sin token en
+imagen, logs ni runtime— **en los dos RUN de cada Dockerfile**, que es donde el primer deploy de Globe se
+había estrellado (`--mount=type=secret` es por-RUN y `pnpm deploy --prod` re-resuelve después). Incluye
+extensión del `worker-build-contract-gate` con su test.
+
+### ⚠️ Acoplamiento cross-proyecto: deliberado, temporal, y con condición de retiro
+
+Para habilitarlo se concedió `roles/secretmanager.secretAccessor` **sobre ese único secreto** al SA de Cloud
+Build de Greenhouse:
+
+```
+axis-packages-read-token  (vive en GCP efeonce-globe)
+  ├── 818083690953-compute@  ← Cloud Build de Globe        (preexistente)
+  └── 183008134038-compute@  ← Cloud Build de Greenhouse   (agregado 2026-07-29)
+```
+
+**Se decidió NO duplicar el secreto.** Dos copias son dos rotaciones, y con el PAT venciendo el 2026-08-27 la
+segunda es la que alguien olvida.
+
+**Pero hay que verlo por lo que es:** `axis-packages-read-token` es una credencial **del ecosistema AXIS**
+archivada en el proyecto de un **producto**, porque ese producto la necesitó primero. La consecuencia es que
+**los builds de Greenhouse dependen hoy del proyecto GCP de Globe** — lo que invierte la dirección de
+gobierno, ya que Greenhouse gobierna a Globe.
+
+🔴 **Condición de retiro — y es una DECISIÓN, no un vencimiento automático.** Al reemplazar el PAT por la
+identidad de máquina (requisito previo a rollout externo, §7), el secreto nuevo **debe nacer fuera del
+proyecto de un producto**. Si simplemente se recrea en `efeonce-globe`, **el acoplamiento se reinstala en
+silencio y nadie lo nota**, porque todo sigue funcionando. Es el único momento en que retirarlo cuesta cero.
+
+---
+
 ## 3. Qué falta en GREENHOUSE
 
 | Falta | Archivo / superficie | Nota |
@@ -183,7 +227,8 @@ Son evidencia de promoción, no capacidad. Se cierran juntos en una pasada.
 
 | Gate | Estado | Detalle |
 |---|---|---|
-| PAT → identidad de máquina | 🔴 **con reloj: 2026-08-27** | Operator-owned. Requisito declarado antes de rollout externo. |
+| PAT → identidad de máquina | 🔴 **con reloj: 2026-08-27** | Operator-owned. Requisito declarado antes de rollout externo. **Es también la única ventana barata para retirar el acoplamiento cross-proyecto de §2-bis** — el secreto nuevo debe nacer fuera del proyecto de un producto. |
+| Credencial AXIS en proyecto neutral | ❌ vive en `efeonce-globe` (proyecto de un producto) | Ver §2-bis. Aceptado como temporal para no crear una segunda copia que rotar. |
 | Secreto nunca en la imagen | ✅ | BuildKit `--mount=type=secret`, montado en **ambos** RUNs desde el fix del Delta. |
 | Token nunca en logs ni lockfile | ✅ | `trap 'rm -f .npmrc' EXIT` en Actions. |
 | Paquetes privados, no públicos | ✅ | El runbook lo prohíbe explícitamente como atajo. |

--- a/docs/operations/AXIS_CONTINUITY_MAP_2026-07-29.md
+++ b/docs/operations/AXIS_CONTINUITY_MAP_2026-07-29.md
@@ -1,0 +1,266 @@
+# AXIS — Mapa de continuidad ejecutable
+
+> **Tipo de documento:** Diagnóstico de continuidad (no es arquitectura ni decisión)
+> **Creado:** 2026-07-29 por Claude (Opus 5)
+> **Alcance:** AXIS (design system) × Greenhouse (consumidor/integrador) × Globe (producto comercial consumidor)
+> **Método:** verificado contra repos, lockfiles, `node_modules`, Vercel y workflows reales — **no contra la documentación**, que en tres puntos resultó stale.
+> **Autoridad:** este documento **no** supersede nada. La decisión vive en
+> [`EFEONCE_SHARED_PRODUCT_UI_PLATFORM_DECISION_V1`](../architecture/EFEONCE_SHARED_PRODUCT_UI_PLATFORM_DECISION_V1.md);
+> el runbook operativo en [`AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1`](./AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md).
+
+---
+
+## 0. Los cuatro actores, y por qué confundirlos es caro
+
+| Actor | Qué es | Qué NO es | Repo dueño |
+|---|---|---|---|
+| **AXIS** | El **design system comercial de Efeonce**: tokens, contratos y registry, distribuidos como **paquetes privados versionados**. | No es "el design system de Greenhouse renombrado". No es una biblioteca de componentes. | `efeoncepro/axis-design-system` |
+| **Greenhouse** | **Consumidor e integrador**, y además el **control plane documental y de tasks** de todo el ecosistema. | No es el dueño de AXIS. Su implementación MUI/Vuexy **no** viaja en los paquetes. | `efeoncepro/greenhouse-eo` |
+| **Globe** | **Producto comercial** que consume AXIS con su propio motor (Tailwind v4 + tokens propios). | No hereda la UI de Greenhouse ni importa MUI/Vuexy (ADR-014). | `efeoncepro/efeonce-globe` |
+| **El Lab** | **Fuente de primitives y evidencia**: superficie de exploración y verificación visual del design system. | **NO es producto final** ni superficie de cliente. Que algo exista en el Lab no lo hace promovido. | `axis-design-system-lab` (Vercel) |
+
+La regla que cae de esto y que gobierna todo lo demás: **un contrato compartido no obliga a compartir el
+motor de estilos** (Regla 2 del ADR). AXIS distribuye *contratos y tokens*; cada producto materializa su
+propio adapter.
+
+---
+
+## 1. Qué está TERMINADO
+
+Todo lo de esta sección está verificado contra artefactos, no contra prosa.
+
+### Distribución y publicación — cerrado
+
+| Hecho | Evidencia verificada |
+|---|---|
+| Tres paquetes en `0.1.4` | `@efeoncepro/axis-tokens`, `axis-ui-contracts`, `axis-ui-registry` |
+| **Publicados de verdad** en GitHub Packages | El lockfile de Globe trae **tarball real + integrity** de `npm.pkg.github.com` — prueba de resolución, no de intención |
+| El tag dispara la publicación | `release-packages.yml` corre `on: push: tags: v*.*.*` |
+| `v0.1.4` está en `origin` y apunta al HEAD | `v0.1.4` == `10af569` == `HEAD`; repo en `main`, árbol limpio |
+
+### Acceso y credenciales — cerrado (con reloj, ver §7)
+
+- Acceso `Read` de GitHub Actions concedido a `greenhouse-eo` y `efeonce-globe` sobre los tres paquetes.
+- Secreto `axis-packages-read-token` en Secret Manager de `efeonce-globe`; el SA de Cloud Build
+  (`818083690953-compute@…`) tiene `secretAccessor` **a nivel de secreto**, no de proyecto.
+- Vercel `NPM_RC` en `axis-design-system-lab` (Production + Preview).
+
+### Consumo — cerrado como piloto opt-in en LOS DOS runtimes
+
+| | Greenhouse | Globe |
+|---|---|---|
+| Declara `0.1.4` | `package.json` raíz | `apps/studio-client/package.json` |
+| Instalado | ✅ `node_modules/@efeoncepro/*` | ✅ `apps/studio-client/node_modules/@efeoncepro/*` |
+| Superficie del piloto | `/design-system/axis-adapters` | `/_axis-pilot` |
+| Adapters | MUI/Vuexy | Tailwind + token classes (`AxisStatus`, `AxisProgress`) |
+| Auth en CI | ✅ **10 workflows** con `npm.pkg.github.com` | ✅ `ci.yml` materializa `GITHUB_TOKEN` con `trap 'rm -f .npmrc' EXIT` |
+
+### Cloud Build de Globe — **PROBADO EN PRODUCCIÓN, contra lo que dice el runbook**
+
+Esta es la corrección más importante del diagnóstico. El runbook y `TASK-1591` declaran que *«falta ejecutar
+una corrida real de CI/Cloud Build»*. **Para Cloud Build ya no falta.**
+
+El primer deploy con paquetes privados **falló** (`ERR_PNPM_FETCH_404`, run 30438182204) porque
+`--mount=type=secret` es **por-RUN** y `pnpm deploy --legacy --prod` re-resuelve dependencias en un RUN
+posterior sin `.npmrc`. Se corrigió montando el secreto en el segundo RUN, y **el deploy posterior quedó
+verde y verificado en Cloud Run**. Desde entonces, **cuatro deploys más** el 2026-07-29 pasaron por ese mismo
+Dockerfile (`68a2cbe`, `d009871`, `b9112a8`, `403d346`; revisión viva `00101-x2d`).
+
+> **La lección que quedó y que hay que conservar:** la distribución de paquetes privados **no queda probada al
+> publicarlos ni al instalarlos en local — se prueba en la primera imagen de producción que los consume.**
+
+---
+
+## 2. Qué está PARCIALMENTE implementado
+
+| # | Qué | Estado real | Por qué no está cerrado |
+|---|---|---|---|
+| **P1** | Corrida real de **GitHub Actions** con install de AXIS | ⚠️ **NO VERIFICADO** | El wiring existe en los dos repos y hubo pushes hoy que debieron dispararlo, pero **no pude confirmar la conclusión**: la API de GitHub estaba en rate limit (0/5000). **No se asume verde.** |
+| **P2** | Verificación de **digest desplegado** | ❌ falta | Declarado requisito de promoción en `TASK-1591` y en el runbook. Cloud Build corre verde, pero nadie verificó que el digest servido corresponda al build con AXIS. |
+| **P3** | **Rollback probado** | ❌ falta | Existe `rollback-internal.yml`, pero no hay evidencia de un rollback ejercido con AXIS adentro. |
+| **P4** | Promoción del **registry a `stable`** | ❌ bloqueado por diseño | El ADR es explícito: *«`TASK-1485` pasa a ser consumer/piloto de la plataforma compartida y **debe actualizarse antes de promover el registry como estable**»*. |
+| **P5** | `TASK-1485` (motor de estilos + governance de Globe) | `to-do`, **desbloqueada** | Ver §6: su `Blocked by` está stale. |
+| **P6** | `TASK-1552` Slice 3 | `in-progress` | Estados de ejecución y evidencia premium del composer. Consume el motor que gobierna `TASK-1485`. |
+
+---
+
+## 3. Qué falta en GREENHOUSE
+
+| Falta | Archivo / superficie | Nota |
+|---|---|---|
+| **Actualizar `TASK-1485`** al rol que el ADR le asigna | `docs/tasks/to-do/TASK-1485-*.md` | El ADR lo exige **antes** de promover el registry. Hoy la task no refleja que es consumer de la plataforma compartida. |
+| **Corregir el `Blocked by` stale** | misma task | Declara `TASK-1455`, que está **`complete`**. |
+| **Sincronizar el runbook** con la realidad | `AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md` | Tres puntos stale, ver §7. |
+| **Reemplazar el PAT por identidad de máquina** | operación, no código | Es el único ítem con fecha. Ver §7. |
+
+**No falta** (verificado, y el runbook no lo dice): `NPM_RC` **sí existe** en el proyecto Vercel de
+`greenhouse-eo`, para `staging`, `Production` y `Preview (develop)`. El runbook solo menciona el proyecto del
+Lab.
+
+---
+
+## 4. Qué falta en GLOBE
+
+| Falta | Archivo / superficie | Nota |
+|---|---|---|
+| **Promoción de los adapters a superficie de producto** | `apps/studio-client/src/primitives/index.tsx` | Hoy `AxisStatus`/`AxisProgress` viven en el piloto opt-in `/_axis-pilot`. Promoverlos es decisión separada del piloto. |
+| **Cerrar `TASK-1552` Slice 3** | composer | Único slice abierto de la superficie que más consume el motor. |
+| **Higiene del store de paquetes** | `node_modules/.pnpm/` | Conviven `0.1.3` **y** `0.1.4`. No rompe nada hoy, pero un consumer que resuelva la vieja no daría error. |
+| **Rama WIP sin cerrar** | `task/TASK-1552-slice0-internalizar-css` | Congelada con partes a revertir según el propio `TASK-1552`. Decidir si se retira o se retoma. |
+
+---
+
+## 5. Dependencias entre los tres
+
+```
+AXIS (axis-design-system)
+  │  publica @efeoncepro/axis-{tokens,ui-contracts,ui-registry} 0.1.4
+  │  ⇩ tag v*.*.* → release-packages.yml → GitHub Packages (privado)
+  │
+  ├─► GREENHOUSE ── consume vía package.json raíz + adapters MUI/Vuexy
+  │     │            auth: GITHUB_TOKEN en Actions · NPM_RC en Vercel
+  │     │
+  │     └─► gobierna a Globe (tasks, ADRs, doc) ── NO le presta su motor
+  │
+  └─► GLOBE ─────── consume vía apps/studio-client + adapters Tailwind
+        auth: GITHUB_TOKEN en Actions · axis-packages-read-token en Cloud Build
+```
+
+**Dependencias duras:**
+
+1. **Promover el registry a `stable`** ⟵ requiere **`TASK-1485` actualizada** (exigencia explícita del ADR).
+2. **Rollout externo/comercial** ⟵ requiere **identidad de máquina** en lugar del PAT (§7) **y** `TASK-1480`,
+   que hoy tiene conditional-go solo para el primer **Commercial Production Sprint managed**; el
+   SaaS/client-runtime externo **sigue gated**.
+3. **`TASK-1552` Slice 3** ⟵ consume el motor de estilos cuyo contrato gobierna **`TASK-1485`**. Avanzar el
+   composer sin cerrar la governance deja el motor sin dueño formal mientras se le agregan consumers.
+4. **Cualquier bump de versión AXIS** ⟵ toca **los dos** consumers a la vez (lockfile + adapters). No hay
+   canario que lo pruebe cross-repo hoy.
+
+**Dependencia que NO existe, y conviene decirlo:** Globe **no** depende del build de Greenhouse. Son
+toolchains independientes; lo único compartido son los paquetes versionados.
+
+---
+
+## 6. Qué task ejecutar PRIMERO
+
+### 🔴 `TASK-1485` — y el hallazgo es que **ya no está bloqueada**
+
+Su cabecera declara `Blocked by: TASK-1455`, pero **`TASK-1455` está `complete`** (*"shell internal-only live
+y verificada en Cloud Run"*). El bloqueo es **stale**: la task es ejecutable hoy.
+
+Por qué va primera, en orden de fuerza del argumento:
+
+1. **El ADR la nombra como precondición.** Promover el registry a `stable` está explícitamente condicionado a
+   actualizarla. Nada de la cadena comercial avanza sin eso.
+2. **Es dueña del motor de estilos de Globe** (ADR-016, incorporado por el Delta 2026-07-27). Hoy
+   `TASK-1552` le está agregando consumers a un motor cuya governance está en `to-do` — se acumula superficie
+   sobre un contrato sin cerrar.
+3. **Es barata comparada con lo que desbloquea.** Su trabajo es contrato y registry, no runtime.
+
+### Segundo: la identidad de máquina del PAT
+
+Es lo único con **fecha de vencimiento** (2026-08-27, ~4 semanas). No bloquea a `TASK-1485`, así que corren en
+paralelo — pero **empeora solo**: cuando el token venza, el build rompe y el mensaje de npm miente (dice *«is
+not in the npm registry»*, que es falso).
+
+### Tercero: cerrar P1–P3 (corrida CI + digest + rollback)
+
+Son evidencia de promoción, no capacidad. Se cierran juntos en una pasada.
+
+### Lo que **NO** debe ir primero
+
+- **`TASK-1552` Slice 3** — le agrega consumers al motor antes de cerrar su governance.
+- **Promover adapters a producto en Globe** — es exactamente lo que el ADR y `TASK-1591` mantienen separado
+  del piloto.
+- **Bump de versión AXIS** — sin canario cross-repo, un bump hoy se prueba en producción.
+
+---
+
+## 7. Gates que faltan
+
+### Seguridad / credenciales
+
+| Gate | Estado | Detalle |
+|---|---|---|
+| PAT → identidad de máquina | 🔴 **con reloj: 2026-08-27** | Operator-owned. Requisito declarado antes de rollout externo. |
+| Secreto nunca en la imagen | ✅ | BuildKit `--mount=type=secret`, montado en **ambos** RUNs desde el fix del Delta. |
+| Token nunca en logs ni lockfile | ✅ | `trap 'rm -f .npmrc' EXIT` en Actions. |
+| Paquetes privados, no públicos | ✅ | El runbook lo prohíbe explícitamente como atajo. |
+
+### Paquete privado
+
+| Gate | Estado |
+|---|---|
+| Versiones fijadas (no rangos) | ✅ `"0.1.4"` exacto en los dos consumers |
+| Registry scoped `@efeoncepro` | ✅ en CI; **`.npmrc` deliberadamente NO committeado** (llevaría token) — se materializa efímero |
+| Canario cross-repo ante un bump | ❌ **no existe** |
+
+### Vercel
+
+| Gate | Estado |
+|---|---|
+| `NPM_RC` en el Lab | ✅ Production + Preview |
+| `NPM_RC` en `greenhouse-eo` | ✅ staging + Production + Preview — **el runbook no lo dice** |
+| Globe en Vercel | n/a — Globe corre en Cloud Run, no Vercel |
+
+### CI
+
+| Gate | Estado |
+|---|---|
+| Wiring en Greenhouse | ✅ 10 workflows |
+| Wiring en Globe (`ci.yml`) | ✅ |
+| **Corrida real verde con AXIS** | ⚠️ **NO VERIFICADO** (rate limit de la API). No se asume. |
+
+### Runtime
+
+| Gate | Estado |
+|---|---|
+| Cloud Build de Globe con AXIS | ✅ **probado**: 1 fallo + fix + 5 deploys verdes |
+| Canario del piloto | ✅ `axis-pilot-canary.test.mjs`, 16 asertos; su leak de proceso se cerró el 2026-07-29 |
+| Digest desplegado verificado | ❌ |
+| Rollback ejercido con AXIS | ❌ |
+
+---
+
+## 8. Documentación stale detectada (corregir al ejecutar, no antes)
+
+1. **Runbook** — *«falta ejecutar una corrida real de CI/Cloud Build»*: para **Cloud Build ya se ejecutó**,
+   falló, se corrigió y lleva 5 deploys verdes. Lo que sigue sin verificar es **GitHub Actions**.
+2. **Runbook** — solo menciona `NPM_RC` en el proyecto Vercel del Lab; **también existe en `greenhouse-eo`**.
+3. **`TASK-1485`** — `Blocked by: TASK-1455`, que está `complete`.
+
+> Se dejan **anotadas y sin corregir** a propósito: corregirlas es parte del arranque de `TASK-1485`, y un
+> barrido documental suelto ahora mezclaría el diagnóstico con la ejecución.
+
+---
+
+## 9. Handoff — para arrancar sin releer nada
+
+**Estado de partida (2026-07-29):**
+
+- AXIS `0.1.4` publicado y consumido por los dos productos como **piloto opt-in verificado**.
+- Globe: `main` limpio, revisión viva `globe-studio-internal-00101-x2d` sirviendo `403d3464e88e`.
+- Greenhouse: `develop` pusheado y sincronizado. **El release develop→main ya se completó — no repetirlo.**
+- Rama abierta en Globe: `task/TASK-1552-slice0-internalizar-css` (WIP congelado, decidir retiro).
+
+**Siguiente paso recomendado, concreto:**
+
+> Abrir **`TASK-1485`**. Primer movimiento: corregir su `Blocked by` (stale) y actualizarla al rol que el ADR
+> le asigna — **consumer/piloto de la plataforma compartida**, dueña del motor de estilos de Globe (ADR-016) y
+> **precondición declarada para promover el registry a `stable`**. Recargar la skill
+> `greenhouse-task-planner` completa antes de editarla; el cierre exige `pnpm task:lint --task TASK-1485` en
+> `errors=0 warnings=0`.
+
+**Dos cosas que hay que verificar en cuanto la API de GitHub deje de estar en rate limit:**
+
+```bash
+gh run list --repo efeoncepro/efeonce-globe  --workflow=ci.yml --limit 5
+gh run list --repo efeoncepro/greenhouse-eo  --workflow=ci.yml --limit 5
+```
+
+Si alguna corrió verde con el install de AXIS, **P1 se cierra sin trabajo**. Si ninguna tocó el path, hay que
+provocarla.
+
+**Lo que NO hay que hacer todavía:** promover adapters a superficie de producto, bumpear la versión de AXIS,
+avanzar `TASK-1552` Slice 3, ni tocar el release develop→main.

--- a/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
+++ b/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
@@ -20,8 +20,8 @@ source control.
   `efeoncepro/efeonce-globe` on all three packages.
 - Vercel `NPM_RC` is configured on `axis-design-system-lab` for Production and Preview.
 - GCP Secret Manager secret `axis-packages-read-token` exists in `efeonce-globe`; the
-  Compute Engine service account used by Cloud Build has secret-level
-  `roles/secretmanager.secretAccessor`.
+  Compute Engine service accounts used by Globe and Greenhouse Cloud Build have
+  secret-level `roles/secretmanager.secretAccessor`.
 - The current PAT is operator-owned and expires on 2026-08-27. Replace it with a
   dedicated machine identity before the first external/customer rollout.
 - Local private-package installation for the TASK-1591 canary was verified with a temporary
@@ -70,7 +70,7 @@ PAT classic with `read:packages` only; do not use a personal deployment token.
 After setting `NPM_RC`, trigger a new deployment. Environment changes do not affect
 previous deployments.
 
-## Cloud Build / Globe
+## Cloud Build / Globe and Greenhouse workers
 
 Store the organization-owned read-only token in Secret Manager in the `efeonce-globe`
 project. Grant the build service account access to that one secret only. The build
@@ -84,11 +84,23 @@ Current secret reference:
 projects/efeonce-globe/secrets/axis-packages-read-token
 ```
 
-Current build identity:
+Current Globe build identity:
 
 ```text
 818083690953-compute@developer.gserviceaccount.com
 ```
+
+Greenhouse worker build identity:
+
+```text
+183008134038-compute@developer.gserviceaccount.com
+```
+
+The Greenhouse deploy scripts for `ops-worker`, `commercial-cost-worker` and
+`ico-batch-worker` use the same contract. Their Dockerfiles mount the secret in
+both the builder and runtime `pnpm install` layers because BuildKit secrets are
+scoped to one `RUN`; the token is never passed as a Docker build argument or
+copied into the image.
 
 The deployment workflow must prove:
 

--- a/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
+++ b/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
@@ -105,10 +105,11 @@ Greenhouse binding to this legacy secret, and remove the legacy secret only afte
 consumers pass their build and digest gates. Do not recreate the coupling by placing the
 replacement secret in `efeonce-globe` merely because the legacy secret is there today.
 
-The Greenhouse deploy scripts for `ops-worker`, `commercial-cost-worker` and
-`ico-batch-worker` use the same contract. Their Dockerfiles mount the secret in
-both the builder and runtime `pnpm install` layers because BuildKit secrets are
-scoped to one `RUN`; the token is never passed as a Docker build argument or
+The Greenhouse deploy scripts for `ops-worker`, `commercial-cost-worker`,
+`ico-batch-worker` and the staging-only `artifact-worker` use the same contract.
+The service Dockerfiles mount the secret in both builder and runtime installs;
+the single-stage artifact worker mounts it in its only `pnpm install`. BuildKit
+secrets are scoped to one `RUN`; the token is never passed as a Docker build argument or
 copied into the image.
 
 The deployment workflow must prove:

--- a/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
+++ b/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
@@ -19,9 +19,10 @@ source control.
 - GitHub Actions read access is configured for `efeoncepro/greenhouse-eo` and
   `efeoncepro/efeonce-globe` on all three packages.
 - Vercel `NPM_RC` is configured on `axis-design-system-lab` for Production and Preview.
-- GCP Secret Manager secret `axis-packages-read-token` exists in `efeonce-globe`; the
-  Compute Engine service accounts used by Globe and Greenhouse Cloud Build have
-  secret-level `roles/secretmanager.secretAccessor`.
+- GCP Secret Manager secret `axis-packages-read-token` exists in `efeonce-globe`; this
+  is deliberate ecosystem ownership, not a Globe-only credential. The Compute Engine
+  service accounts used by Globe and Greenhouse Cloud Build have secret-level
+  `roles/secretmanager.secretAccessor`.
 - The current PAT is operator-owned and expires on 2026-08-27. Replace it with a
   dedicated machine identity before the first external/customer rollout.
 - Local private-package installation for the TASK-1591 canary was verified with a temporary
@@ -95,6 +96,12 @@ Greenhouse worker build identity:
 ```text
 183008134038-compute@developer.gserviceaccount.com
 ```
+
+This cross-project binding is temporary and intentionally avoids a second copy of the
+PAT. When the dedicated machine identity replaces the operator-owned PAT, create the
+replacement secret under the ecosystem owner, migrate both consumers, revoke the
+Greenhouse binding to this legacy secret, and remove the legacy secret only after both
+consumers pass their build and digest gates.
 
 The Greenhouse deploy scripts for `ops-worker`, `commercial-cost-worker` and
 `ico-batch-worker` use the same contract. Their Dockerfiles mount the secret in

--- a/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
+++ b/docs/operations/AXIS_PRIVATE_PACKAGE_CONSUMPTION_RUNBOOK_V1.md
@@ -98,10 +98,12 @@ Greenhouse worker build identity:
 ```
 
 This cross-project binding is temporary and intentionally avoids a second copy of the
-PAT. When the dedicated machine identity replaces the operator-owned PAT, create the
-replacement secret under the ecosystem owner, migrate both consumers, revoke the
+PAT. The retirement condition is an ownership decision, not the PAT expiry: when the
+dedicated machine identity is created, its replacement secret must be born in a neutral
+AXIS ecosystem project outside any product project. Migrate both consumers, revoke the
 Greenhouse binding to this legacy secret, and remove the legacy secret only after both
-consumers pass their build and digest gates.
+consumers pass their build and digest gates. Do not recreate the coupling by placing the
+replacement secret in `efeonce-globe` merely because the legacy secret is there today.
 
 The Greenhouse deploy scripts for `ops-worker`, `commercial-cost-worker` and
 `ico-batch-worker` use the same contract. Their Dockerfiles mount the secret in

--- a/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
+++ b/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
@@ -89,6 +89,16 @@ test('deploy scripts preservan el escape de Cloud Build para el token AXIS', () 
   }
 })
 
+test('los contextos de build excluyen el npmrc efímero', () => {
+  for (const ignorePath of ['.dockerignore', '.gcloudignore']) {
+    const rules = readFileSync(resolve(process.cwd(), ignorePath), 'utf8')
+      .split('\n')
+      .map(line => line.trim())
+
+    assert.ok(rules.includes('.npmrc'), `${ignorePath} debe excluir .npmrc`)
+  }
+})
+
 test('workflow toolchain hereda packageManager y bloquea versiones duplicadas', () => {
   const valid = { jobs: { test: { steps: [{ uses: 'pnpm/action-setup@v6' }] } } }
   const invalid = { jobs: { test: { steps: [{ uses: 'pnpm/action-setup@v4', with: { version: '10.9.0' } }] } } }

--- a/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
+++ b/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
@@ -62,17 +62,33 @@ ARG PNPM_VERSION=10.32.1
 COPY vendor/ ./vendor/
 RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true pnpm install --prod`,
     pnpmVersion: '10.32.1',
-    localDependencies: [{ path: 'vendor/package.tgz' }]
+    localDependencies: [{ path: 'vendor/package.tgz' }],
+    requiresPrivatePackageAuth: true
   })
 
   assert.deepEqual(findings, [])
+})
+
+test('validateDockerfile bloquea private package install sin secreto BuildKit', () => {
+  const findings = validateDockerfile({
+    source: `FROM node:22
+ARG PNPM_VERSION=10.32.1
+COPY vendor/ ./vendor/
+RUN pnpm install --frozen-lockfile`,
+    pnpmVersion: '10.32.1',
+    localDependencies: [{ path: 'vendor/package.tgz' }],
+    requiresPrivatePackageAuth: true
+  })
+
+  assert.match(findings.join('\n'), /debe montar el secreto BuildKit axis_npmrc/)
 })
 
 test('deploy scripts preservan el escape de Cloud Build para el token AXIS', () => {
   const deployScripts = [
     'services/ops-worker/deploy.sh',
     'services/commercial-cost-worker/deploy.sh',
-    'services/ico-batch/deploy.sh'
+    'services/ico-batch/deploy.sh',
+    'services/artifact-worker/deploy.sh'
   ]
 
   for (const scriptPath of deployScripts) {

--- a/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
+++ b/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
@@ -47,6 +47,25 @@ test('validateDockerfile acepta cada etapa determinística', () => {
   assert.deepEqual(findings, [])
 })
 
+test('validateDockerfile acepta pnpm install con secreto BuildKit', () => {
+  const findings = validateDockerfile({
+    source: `# syntax=docker/dockerfile:1.7
+FROM node:22 AS builder
+ARG PNPM_VERSION=10.32.1
+COPY vendor/ ./vendor/
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \\
+  pnpm install --frozen-lockfile
+FROM node:22
+ARG PNPM_VERSION=10.32.1
+COPY vendor/ ./vendor/
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true pnpm install --prod`,
+    pnpmVersion: '10.32.1',
+    localDependencies: [{ path: 'vendor/package.tgz' }]
+  })
+
+  assert.deepEqual(findings, [])
+})
+
 test('workflow toolchain hereda packageManager y bloquea versiones duplicadas', () => {
   const valid = { jobs: { test: { steps: [{ uses: 'pnpm/action-setup@v6' }] } } }
   const invalid = { jobs: { test: { steps: [{ uses: 'pnpm/action-setup@v4', with: { version: '10.9.0' } }] } } }

--- a/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
+++ b/scripts/ci/__tests__/worker-build-contract-gate.test.mjs
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import test from 'node:test'
 
 import {
@@ -64,6 +66,27 @@ RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true pnpm ins
   })
 
   assert.deepEqual(findings, [])
+})
+
+test('deploy scripts preservan el escape de Cloud Build para el token AXIS', () => {
+  const deployScripts = [
+    'services/ops-worker/deploy.sh',
+    'services/commercial-cost-worker/deploy.sh',
+    'services/ico-batch/deploy.sh'
+  ]
+
+  for (const scriptPath of deployScripts) {
+    const source = readFileSync(resolve(process.cwd(), scriptPath), 'utf8')
+
+    assert.ok(
+      source.includes('\\$\\${AXIS_PACKAGES_READ_TOKEN}'),
+      `${scriptPath} debe emitir $${'{'}AXIS_PACKAGES_READ_TOKEN} al config de Cloud Build`
+    )
+    assert.ok(
+      !source.includes('_authToken=$${AXIS_PACKAGES_READ_TOKEN}'),
+      `${scriptPath} no debe expandir $$ como PID del shell que genera el config`
+    )
+  }
 })
 
 test('workflow toolchain hereda packageManager y bloquea versiones duplicadas', () => {

--- a/scripts/ci/worker-build-contract-gate.mjs
+++ b/scripts/ci/worker-build-contract-gate.mjs
@@ -64,7 +64,7 @@ export const collectLocalFileDependencies = pkg => {
 export const splitDockerStages = dockerfile =>
   dockerfile.split(/(?=^FROM\s+)/gim).filter(stage => /^FROM\s+/im.test(stage))
 
-export const validateDockerfile = ({ source, pnpmVersion, localDependencies }) => {
+export const validateDockerfile = ({ source, pnpmVersion, localDependencies, requiresPrivatePackageAuth = false }) => {
   const errors = []
   // Docker BuildKit options may precede the command and line continuations may
   // split `RUN --mount=... pnpm install` across physical lines.
@@ -76,6 +76,13 @@ export const validateDockerfile = ({ source, pnpmVersion, localDependencies }) =
     const installsDependencies = /RUN(?:\s+--[^\n]+)*\s+pnpm\s+install\b/i.test(stage)
 
     if (!installsDependencies) continue
+
+    if (
+      requiresPrivatePackageAuth &&
+      !/RUN\s+--mount=type=secret,id=axis_npmrc,[^\n]*\s+pnpm\s+install\b/i.test(stage)
+    ) {
+      errors.push(`stage ${index + 1}: pnpm install debe montar el secreto BuildKit axis_npmrc`)
+    }
 
     const versionMatches = [...stage.matchAll(/^ARG\s+PNPM_VERSION=([^\s]+)$/gim)].map(match => match[1])
 
@@ -222,6 +229,10 @@ export const runWorkerBuildContractGate = (root = repoRoot) => {
   const pnpmVersion = parsePnpmVersion(pkg.packageManager)
   const localDependencies = collectLocalFileDependencies(pkg)
 
+  const requiresPrivatePackageAuth = Object.keys(pkg.dependencies ?? {}).some(name =>
+    name.startsWith('@efeoncepro/axis-')
+  )
+
   if (localDependencies.length === 0) {
     console.log('• No hay dependencias file: locales; se mantienen los demás contratos de build.')
   }
@@ -235,7 +246,8 @@ export const runWorkerBuildContractGate = (root = repoRoot) => {
       ...validateDockerfile({
         source: readText(root, unit.dockerfile),
         pnpmVersion,
-        localDependencies
+        localDependencies,
+        requiresPrivatePackageAuth
       }).map(error => `${unit.dockerfile}: ${error}`)
     )
 

--- a/scripts/ci/worker-build-contract-gate.mjs
+++ b/scripts/ci/worker-build-contract-gate.mjs
@@ -195,9 +195,24 @@ export const validateWorkerWorkflowPaths = ({ path, workflow }) => {
 const validateIgnoreContract = ({ root, path }) => {
   const source = readText(root, path)
 
-  return source.includes('!vendor/efeonce-globe/**')
-    ? []
-    : [`${path}: debe incluir explícitamente !vendor/efeonce-globe/**`]
+  const rules = new Set(
+    source
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#'))
+  )
+
+  const errors = []
+
+  if (!rules.has('!vendor/efeonce-globe/**')) {
+    errors.push(`${path}: debe incluir explícitamente !vendor/efeonce-globe/**`)
+  }
+
+  if (!rules.has('.npmrc')) {
+    errors.push(`${path}: debe excluir .npmrc para que credenciales de package install no entren al build context`)
+  }
+
+  return errors
 }
 
 export const runWorkerBuildContractGate = (root = repoRoot) => {

--- a/scripts/ci/worker-build-contract-gate.mjs
+++ b/scripts/ci/worker-build-contract-gate.mjs
@@ -66,11 +66,14 @@ export const splitDockerStages = dockerfile =>
 
 export const validateDockerfile = ({ source, pnpmVersion, localDependencies }) => {
   const errors = []
-  const stages = splitDockerStages(source)
+  // Docker BuildKit options may precede the command and line continuations may
+  // split `RUN --mount=... pnpm install` across physical lines.
+  const normalizedSource = source.replace(/\\\s*\n/g, ' ')
+  const stages = splitDockerStages(normalizedSource)
   const localDependencyRoots = [...new Set(localDependencies.map(item => item.path.split('/')[0]).filter(Boolean))]
 
   for (const [index, stage] of stages.entries()) {
-    const installsDependencies = /RUN\s+pnpm\s+install\b/i.test(stage)
+    const installsDependencies = /RUN(?:\s+--[^\n]+)*\s+pnpm\s+install\b/i.test(stage)
 
     if (!installsDependencies) continue
 
@@ -86,7 +89,7 @@ export const validateDockerfile = ({ source, pnpmVersion, localDependencies }) =
         'im'
       )
 
-      const installOffset = stage.search(/RUN\s+pnpm\s+install\b/i)
+      const installOffset = stage.search(/RUN(?:\s+--[^\n]+)*\s+pnpm\s+install\b/i)
       const copyMatch = copyPattern.exec(stage)
 
       if (!copyMatch || copyMatch.index > installOffset) {
@@ -95,7 +98,7 @@ export const validateDockerfile = ({ source, pnpmVersion, localDependencies }) =
     }
   }
 
-  if (!stages.some(stage => /RUN\s+pnpm\s+install\b/i.test(stage))) {
+  if (!stages.some(stage => /RUN(?:\s+--[^\n]+)*\s+pnpm\s+install\b/i.test(stage))) {
     errors.push('no se encontró ninguna etapa con pnpm install')
   }
 

--- a/services/artifact-worker/Dockerfile
+++ b/services/artifact-worker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # artifact-worker — Cloud Run JOB de render de artefactos (TASK-1391)
 #
 # PRIMER Cloud Run Job del ecosistema (frontera autorizada 2026-07-12, excepción documentada
@@ -29,7 +31,8 @@ COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
 # --ignore-scripts: sin husky/postinstalls en el contenedor (mismo patrón que ops-worker);
 # los binarios nativos (esbuild de tsx, sharp) llegan como optional deps por plataforma.
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src/ ./src/

--- a/services/artifact-worker/deploy.sh
+++ b/services/artifact-worker/deploy.sh
@@ -65,12 +65,31 @@ BUILD_ID="$(gcloud builds submit "${REPO_ROOT}" \
   --format='value(id)' <<EOF
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', '${IMAGE}', '-f', 'services/artifact-worker/Dockerfile', '.']
+    entrypoint: bash
+    secretEnv:
+      - AXIS_PACKAGES_READ_TOKEN
+    args:
+      - -ceu
+      - |
+        trap 'rm -f .npmrc' EXIT
+        umask 077
+        printf '%s\n' \
+          '@efeoncepro:registry=https://npm.pkg.github.com' \
+          "//npm.pkg.github.com/:_authToken=\$\${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+        DOCKER_BUILDKIT=1 docker build \
+          --secret id=axis_npmrc,src=.npmrc \
+          -t '${IMAGE}' \
+          -f 'services/artifact-worker/Dockerfile' \
+          .
   # SELFTEST de la imagen (robustez sistémica): catálogo completo + checksums de fuentes +
   # Chromium + render probe, DENTRO de la imagen recién construida. Falla ⇒ no hay deploy.
   - name: 'gcr.io/cloud-builders/docker'
     args: ['run', '--rm', '${IMAGE}', '--selftest']
 images: ['${IMAGE}']
+availableSecrets:
+  secretManager:
+    - versionName: projects/efeonce-globe/secrets/axis-packages-read-token/versions/latest
+      env: AXIS_PACKAGES_READ_TOKEN
 options:
   machineType: 'E2_HIGHCPU_8'
 EOF

--- a/services/commercial-cost-worker/Dockerfile
+++ b/services/commercial-cost-worker/Dockerfile
@@ -6,6 +6,7 @@
 # Run:    docker run -p 8080:8080 --env-file .env.local commercial-cost-worker
 # Deploy: see services/commercial-cost-worker/deploy.sh
 
+# syntax=docker/dockerfile:1.7
 FROM node:22-slim AS builder
 
 ARG PNPM_VERSION=10.32.1
@@ -16,7 +17,8 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src/ ./src/
@@ -61,7 +63,8 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts --prod
 
 COPY --from=builder /app/dist/server.mjs ./dist/server.mjs
 

--- a/services/commercial-cost-worker/deploy.sh
+++ b/services/commercial-cost-worker/deploy.sh
@@ -74,9 +74,28 @@ BUILD_ID=$(gcloud builds submit . \
   --config=/dev/stdin <<CLOUDBUILD_EOF
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', '${IMAGE}', '-f', 'services/commercial-cost-worker/Dockerfile', '.']
+    entrypoint: bash
+    secretEnv:
+      - AXIS_PACKAGES_READ_TOKEN
+    args:
+      - -ceu
+      - |
+        trap 'rm -f .npmrc' EXIT
+        umask 077
+        printf '%s\n' \
+          '@efeoncepro:registry=https://npm.pkg.github.com' \
+          "//npm.pkg.github.com/:_authToken=$${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+        DOCKER_BUILDKIT=1 docker build \
+          --secret id=axis_npmrc,src=.npmrc \
+          -t '${IMAGE}' \
+          -f 'services/commercial-cost-worker/Dockerfile' \
+          .
 images:
   - '${IMAGE}'
+availableSecrets:
+  secretManager:
+    - versionName: projects/efeonce-globe/secrets/axis-packages-read-token/versions/latest
+      env: AXIS_PACKAGES_READ_TOKEN
 options:
   logging: CLOUD_LOGGING_ONLY
 CLOUDBUILD_EOF

--- a/services/commercial-cost-worker/deploy.sh
+++ b/services/commercial-cost-worker/deploy.sh
@@ -84,7 +84,7 @@ steps:
         umask 077
         printf '%s\n' \
           '@efeoncepro:registry=https://npm.pkg.github.com' \
-          "//npm.pkg.github.com/:_authToken=$${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+          "//npm.pkg.github.com/:_authToken=\$\${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
         DOCKER_BUILDKIT=1 docker build \
           --secret id=axis_npmrc,src=.npmrc \
           -t '${IMAGE}' \

--- a/services/ico-batch/Dockerfile
+++ b/services/ico-batch/Dockerfile
@@ -9,6 +9,7 @@
 
 # ─── Builder stage: install deps + bundle ────────────────────────────────────
 
+# syntax=docker/dockerfile:1.7
 FROM node:22-slim AS builder
 
 ARG PNPM_VERSION=10.32.1
@@ -19,7 +20,8 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src/lib/ ./src/lib/
@@ -63,7 +65,8 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts --prod
 
 COPY --from=builder /app/dist/server.mjs ./dist/server.mjs
 

--- a/services/ico-batch/deploy.sh
+++ b/services/ico-batch/deploy.sh
@@ -49,9 +49,28 @@ BUILD_ID=$(gcloud builds submit . \
   --config=/dev/stdin <<CLOUDBUILD_EOF
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', '${IMAGE}', '-f', 'services/ico-batch/Dockerfile', '.']
+    entrypoint: bash
+    secretEnv:
+      - AXIS_PACKAGES_READ_TOKEN
+    args:
+      - -ceu
+      - |
+        trap 'rm -f .npmrc' EXIT
+        umask 077
+        printf '%s\n' \
+          '@efeoncepro:registry=https://npm.pkg.github.com' \
+          "//npm.pkg.github.com/:_authToken=$${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+        DOCKER_BUILDKIT=1 docker build \
+          --secret id=axis_npmrc,src=.npmrc \
+          -t '${IMAGE}' \
+          -f 'services/ico-batch/Dockerfile' \
+          .
 images:
   - '${IMAGE}'
+availableSecrets:
+  secretManager:
+    - versionName: projects/efeonce-globe/secrets/axis-packages-read-token/versions/latest
+      env: AXIS_PACKAGES_READ_TOKEN
 options:
   logging: CLOUD_LOGGING_ONLY
 CLOUDBUILD_EOF

--- a/services/ico-batch/deploy.sh
+++ b/services/ico-batch/deploy.sh
@@ -59,7 +59,7 @@ steps:
         umask 077
         printf '%s\n' \
           '@efeoncepro:registry=https://npm.pkg.github.com' \
-          "//npm.pkg.github.com/:_authToken=$${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+          "//npm.pkg.github.com/:_authToken=\$\${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
         DOCKER_BUILDKIT=1 docker build \
           --secret id=axis_npmrc,src=.npmrc \
           -t '${IMAGE}' \

--- a/services/ops-worker/Dockerfile
+++ b/services/ops-worker/Dockerfile
@@ -9,6 +9,7 @@
 
 # ─── Builder stage: install deps + bundle ────────────────────────────────────
 
+# syntax=docker/dockerfile:1.7
 FROM node:22-slim AS builder
 
 ARG PNPM_VERSION=10.32.1
@@ -19,7 +20,8 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src/ ./src/
@@ -79,7 +81,8 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY vendor/ ./vendor/
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod
+RUN --mount=type=secret,id=axis_npmrc,target=/root/.npmrc,required=true \
+    pnpm install --frozen-lockfile --ignore-scripts --prod
 
 COPY --from=builder /app/dist/server.mjs ./dist/server.mjs
 

--- a/services/ops-worker/deploy.sh
+++ b/services/ops-worker/deploy.sh
@@ -180,7 +180,7 @@ steps:
         umask 077
         printf '%s\n' \
           '@efeoncepro:registry=https://npm.pkg.github.com' \
-          "//npm.pkg.github.com/:_authToken=$${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+          "//npm.pkg.github.com/:_authToken=\$\${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
         DOCKER_BUILDKIT=1 docker build \
           --secret id=axis_npmrc,src=.npmrc \
           -t '${IMAGE}' \

--- a/services/ops-worker/deploy.sh
+++ b/services/ops-worker/deploy.sh
@@ -170,9 +170,28 @@ BUILD_ID=$(gcloud builds submit . \
   --config=/dev/stdin <<CLOUDBUILD_EOF
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', '${IMAGE}', '-f', 'services/ops-worker/Dockerfile', '.']
+    entrypoint: bash
+    secretEnv:
+      - AXIS_PACKAGES_READ_TOKEN
+    args:
+      - -ceu
+      - |
+        trap 'rm -f .npmrc' EXIT
+        umask 077
+        printf '%s\n' \
+          '@efeoncepro:registry=https://npm.pkg.github.com' \
+          "//npm.pkg.github.com/:_authToken=$${AXIS_PACKAGES_READ_TOKEN}" > .npmrc
+        DOCKER_BUILDKIT=1 docker build \
+          --secret id=axis_npmrc,src=.npmrc \
+          -t '${IMAGE}' \
+          -f 'services/ops-worker/Dockerfile' \
+          .
 images:
   - '${IMAGE}'
+availableSecrets:
+  secretManager:
+    - versionName: projects/efeonce-globe/secrets/axis-packages-read-token/versions/latest
+      env: AXIS_PACKAGES_READ_TOKEN
 options:
   logging: CLOUD_LOGGING_ONLY
 CLOUDBUILD_EOF


### PR DESCRIPTION
Fixes the production release blocker found by orchestrator 30465872005.

- Adds ephemeral Secret Manager + BuildKit auth for private AXIS packages in all four Cloud Build worker units.
- Preserves Cloud Build secret interpolation across the generating heredoc.
- Excludes the ephemeral `.npmrc` from Docker and gcloud build contexts.
- Keeps tokens out of images, logs and runtime.
- Updates the worker build contract gate and canonical AXIS runbook.
- Local worker gates, focused tests, lint, typecheck and docs governance pass.
- Live evidence: three Cloud Run services and the staging-only artifact-worker build/install succeeded with exact digests.

Promote all current develop content; no isolated AXIS release.